### PR TITLE
fixing typo in installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ take advantage of:
 `gulpfile.js`:
 
     var gulp = require('gulp');
-    require('gulp-web-component-tester').initGulp(gulp);
+    require('web-component-tester').initGulp(gulp);
 
 
 ## gulp test:local


### PR DESCRIPTION
package is name web-component-tester, however installation notes say 'gulp-web-component-tester'
