### PR TITLE
Update deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "socket.io": "^1.0.6",
     "stacky": "^1.0.1",
     "uuid": "^1.4.1",
-    "wd": "^0.3.4",
+    "wd": "^0.3.8",
     "yargs": "^1.3.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This change bumps the WebDriver package to 0.3.8 (latest, released last week).
