### PR TITLE
Cli will allow custom webRunner parameters

### DIFF
--- a/runner/cli.js
+++ b/runner/cli.js
@@ -25,7 +25,7 @@ function run(env, args, output, callback) {
     return runTests(options.extraArgs[0], options, done);
   }
 
-  findup(process.cwd(), 'test', function(error, dir) {
+  findup(process.cwd(),  options.webRunner || 'test', function(error, dir) {
     if (error) return done(error);
     runTests(dir, options, done);
   });


### PR DESCRIPTION
Cli now allows for custom webRunner parameters instead of always checking for "test"
