### PR TITLE
Allow runner configuration via file at `./wct.conf.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@ bower install Polymer/web-component-tester --save
 In the following examples, we assume that you've installed it in `../`, but any
 location will do.
 
+## Configuration
+
+You can configure wct via the command line, environment variables, or a
+config file located at `./wct.conf.js`.
+
+### Config File
+
+Config Files should be written in the following format:
+
+```js
+module.exports = function(options) {
+  // options.verbose = true;
+  // options.sauce.username = 'boo';
+  // ...
+
+  return options;
+}
+```
 
 ## Test Index
 

--- a/runner/cli.js
+++ b/runner/cli.js
@@ -17,7 +17,13 @@ var test   = require('./test');
 function run(env, args, output, callback) {
   var done = wrapCallback(output, callback);
 
-  var options = config.mergeDefaults(config.fromEnv(env, args));
+  var options = config.fromEnv(env, args);
+  options = config.mergeDefaults(options);
+  options = config.mergeConfigFile(options);
+
+  // merge defaults after config file to prevent surprising breaks
+  options = config.mergeDefaults(options);
+
   options.output = output;
 
   if (options.extraArgs[0]) {

--- a/runner/config.js
+++ b/runner/config.js
@@ -10,6 +10,7 @@
 var _     = require('lodash');
 var chalk = require('chalk');
 var path  = require('path');
+var fs    = require('fs');
 var yargs = require('yargs');
 
 var browsers = require('./browsers');
@@ -150,8 +151,34 @@ function mergeDefaults(options) {
   return options;
 }
 
+/**
+ * Overrides configuration options via a module function
+ * defined in a config file located at `./wtc.conf.js` and returns
+ * the overridden result.
+ *
+ * @example: overriding the `foo` option
+ *
+ * module.exports = function(options) {
+ *   options.foo = 'boo';
+ *   return options;
+ * }
+ *
+ */
+function mergeConfigFile(options) {
+  var cwd = process.cwd();
+  var configFile = 'wct.conf.js';
+  var configFilePath = path.resolve(cwd, configFile);
+
+  if ( fs.existsSync(configFilePath) ) {
+    return require(configFilePath)(options);
+  } else {
+    return options;
+  }
+}
+
 module.exports = {
   defaults:      defaults,
   fromEnv:       fromEnv,
   mergeDefaults: mergeDefaults,
+  mergeConfigFile: mergeConfigFile
 };


### PR DESCRIPTION
This paves the way for more complex configuration required by things like coverage plugins.
