### PR TITLE
Change web server root to `cwd` by default

### DIFF
--- a/runner/config.js
+++ b/runner/config.js
@@ -34,7 +34,7 @@ function defaults() {
     // Whether the default set of local (or remote) browsers should be targeted.
     remote:      false,
     // The on-disk path where tests & static files should be served from.
-    root:        path.resolve('..'),
+    root:        path.resolve('.'),
     // The component being tested. Must be a directory under `root`.
     component:   path.basename(process.cwd()),
     // The browsers that tests will be run on. Accepts capabilities objects,


### PR DESCRIPTION
I think breaking the 'project is responsible for its own directory' convention is a pretty significant and not necessarily required (our team doesn't need to do it, for example). I propose that if users want the current default behavior it should be configurable (so the convention breaking is obvious), but by default we stick to the cross-platform/cross-language expectation.
