### PR TITLE
Fix reproducible "Aw snap" crash

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -6712,8 +6712,11 @@ ChildRunner.prototype.done = function done() {
 
   this.signalRunComplete();
 
-  if (!this.iframe) return;
-  this.iframe.parentNode.removeChild(this.iframe);
+  if (!this.iframe) return; 
+  var iframe = this.iframe;
+  window.setTimeout( function() {
+    iframe.parentNode.removeChild(iframe);
+  }, 1);
 };
 
 ChildRunner.prototype.signalRunComplete = function signalRunComplete(error) {


### PR DESCRIPTION
I have a reproducible case where I get the "Aw snap" every time I run the tests.

The fix deletes iframe on a timeout, avoiding walking back into a deleted iframe's stack.

My tests are async. This is my guess what the problem is:

ChildRunner.done deletes the iframe.
Right above it in the stack is eventListener for DOMContentLoaded for the iFrame. That frame is now gone, and 'this' points to the deleted window.
When ChildRunner.done returns, I crash immediately.

This is my test suite, also attached are the crash screenshots.

       suite('<pook-auth-ui>', function() {
          test('login mode', function() {
            assert.equal(el.mode, 'login');
          });
          test('login', function(done) {
            TestUtils.setInputValue(email, "b@totic.org");
            TestUtils.setInputValue(password, "12345678");
            el.loginClick(done);
          });
          test('forgotPassword', function(done) {
            TestUtils.setInputValue(
              el.shadowRoot.querySelector('[name=email]'),
              "b@totic.org");
            el.forgotPasswordClick(done);

![beforecrash](https://cloud.githubusercontent.com/assets/127453/5324558/ba6c3c18-7c90-11e4-9401-93e14ce009d0.png)
![aftercrash](https://cloud.githubusercontent.com/assets/127453/5324560/bccbc186-7c90-11e4-91ac-007ceeb76a64.png)