### PR TITLE
Switch placement of html and js examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,19 @@ WCT will [run your tests](#running-your-tests) against whatever browsers you hav
 
 # Getting Started
 
+## `.js` Suites
+
+Your test suites can either be `.js` sources, which run in the context of your
+text index. For example, `test/awesome-tests.js`:
+
+```js
+suite('AwesomeLib', function() {
+  test('is awesome', function() {
+    assert.isTrue(AwesomeLib.awesome);
+  });
+});
+```
+
 ## `.html` Suites
 
 Or, you can write tests in separate `.html` documents. For example,
@@ -41,20 +54,6 @@ Or, you can write tests in separate `.html` documents. For example,
   </script>
 </body>
 </html>
-```
-
-
-## `.js` Suites
-
-Your test suites can either be `.js` sources, which run in the context of your
-text index. For example, `test/awesome-tests.js`:
-
-```js
-suite('AwesomeLib', function() {
-  test('is awesome', function() {
-    assert.isTrue(AwesomeLib.awesome);
-  });
-});
 ```
 
 


### PR DESCRIPTION
It looks like the order was swapped based off the wording in the examples. This reorders the examples so it reads like it's supposed to:

Your test suites can either be `.js` sources...
...
...
Or, you can write tests in separate `.html` documents...
