### PR TITLE
Fix testImmediateAsync catch timeout

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -6985,6 +6985,7 @@ window.testImmediateAsync = function testImmediateAsync(name, testFn) {
     });
   } catch (error) {
     err = error;
+    testComplete = true;
   }
 };
 

--- a/browser/environment/helpers.js
+++ b/browser/environment/helpers.js
@@ -80,6 +80,7 @@ window.testImmediateAsync = function testImmediateAsync(name, testFn) {
     });
   } catch (error) {
     err = error;
+    testComplete = true;
   }
 };
 


### PR DESCRIPTION
If an exception occurs running a test via `testImmediateAsync`, it will never
return as the `err` is updated, but `testComplete` is never set. This small
patch fixes this behaviour.