### PR TITLE
Send test status (pass/fail) to SauceLabs (1/2)

### DIFF
--- a/runner/browserrunner.js
+++ b/runner/browserrunner.js
@@ -136,7 +136,7 @@ BrowserRunner.prototype.done = function done(error) {
     error = this.stats.failing + ' failed tests';
   }
 
-  this.emitter.emit('browser-end', this.def, error, this.stats);
+  this.emitter.emit('browser-end', this.def, error, this.stats, this.sessionId);
 
   // Nothing to quit.
   if (!this.sessionId) {


### PR DESCRIPTION
This is the first part of a change that sends the pass/fail status to SauceLabs. The second part is in wct-sauce [here](https://github.com/Polymer/wct-sauce/pull/4).

This is something i wanted for my own use, but I wanted to send it back as it's a fairly small change.