### PR TITLE
Hang a reference to the ChildRunner's iframe-local wct object

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -700,28 +700,28 @@ Progress.prototype.draw = function(ctx){
       , y = half
       , rad = half - 1
       , fontSize = this._fontSize;
-  
+
     ctx.font = fontSize + 'px ' + this._font;
-  
+
     var angle = Math.PI * 2 * (percent / 100);
     ctx.clearRect(0, 0, size, size);
-  
+
     // outer circle
     ctx.strokeStyle = '#9f9f9f';
     ctx.beginPath();
     ctx.arc(x, y, rad, 0, angle, false);
     ctx.stroke();
-  
+
     // inner circle
     ctx.strokeStyle = '#eee';
     ctx.beginPath();
     ctx.arc(x, y, rad - 1, 0, angle, true);
     ctx.stroke();
-  
+
     // text
     var text = this._text || (percent | 0) + '%'
       , w = ctx.measureText(text).width;
-  
+
     ctx.fillText(
         text
       , x - w / 2 + 1
@@ -4947,7 +4947,7 @@ Runner.prototype.uncaught = function(err){
     debug('uncaught undefined exception');
     err = new Error('Catched undefined error, did you throw without specifying what?');
   }
-  
+
   var runnable = this.currentRunnable;
   if (!runnable || 'failed' == runnable.state) return;
   runnable.clearTimeout();
@@ -6628,20 +6628,6 @@ ChildRunner.get = function(target, traversal) {
 };
 
 /**
- * Hangs a reference to the ChildRunner's iframe-local wct object
- *
- * TODO(thedeeno): This method is odd to document so the achitecture might need
- * a little rework here. Maybe another named concept? Seeing WCT everywhere is
- * pretty confusing. Also, I don't think we need the parentScope.WCT; to limit
- * confusion I didn't include it.
- *
- * @param {object} wct The ChildRunner's iframe-local wct object
- */
-ChildRunner.prototype.prepare = function(wct) {
-  this.share = wct.share;
-};
-
-/**
  * Loads and runs the subsuite.
  *
  * @param {function} done Node-style callback.
@@ -6683,6 +6669,8 @@ ChildRunner.prototype.run = function(done) {
  */
 ChildRunner.prototype.loaded = function(error) {
   WCT.util.debug('ChildRunner#loaded', this.url, error);
+
+  this.share = this.iframe.contentWindow.WCT.share;
   if (error) {
     this.signalRunComplete(error);
     this.done();

--- a/browser/childrunner.js
+++ b/browser/childrunner.js
@@ -65,20 +65,6 @@ ChildRunner.get = function(target, traversal) {
 };
 
 /**
- * Hangs a reference to the ChildRunner's iframe-local wct object
- *
- * TODO(thedeeno): This method is odd to document so the achitecture might need
- * a little rework here. Maybe another named concept? Seeing WCT everywhere is
- * pretty confusing. Also, I don't think we need the parentScope.WCT; to limit
- * confusion I didn't include it.
- *
- * @param {object} wct The ChildRunner's iframe-local wct object
- */
-ChildRunner.prototype.prepare = function(wct) {
-  this.share = wct.share;
-};
-
-/**
  * Loads and runs the subsuite.
  *
  * @param {function} done Node-style callback.
@@ -120,6 +106,8 @@ ChildRunner.prototype.run = function(done) {
  */
 ChildRunner.prototype.loaded = function(error) {
   WCT.util.debug('ChildRunner#loaded', this.url, error);
+  
+  this.share = this.iframe.contentWindow.WCT.share;
   if (error) {
     this.signalRunComplete(error);
     this.done();


### PR DESCRIPTION
Fixes #101.

I removed the "prepare" function (it seemed overly complex for just one line, and the name didn't really make sense for where it is now), and i put the reference to the share variable in.