### PR TITLE
Updates window.flush to refer to Polymer.dom.flush

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1712,8 +1712,8 @@
    * @param {function()} callback
    */
   window.flush = function flush(callback) {
-    // Ideally, this function would be a call to Polymer.flush, but that doesn't
-    // support a callback yet (https://github.com/Polymer/polymer-dev/issues/115),
+    // Ideally, this function would be a call to Polymer.dom.flush, but that doesn't
+    // support a callback yet (https://github.com/Polymer/polymer/issues/851),
     // ...and there's cross-browser flakiness to deal with.
 
     // Make sure that we're invoking the callback with no arguments so that the
@@ -1732,10 +1732,17 @@
     }
 
     // Everyone else gets a regular flush.
-    var scope = window.Polymer || window.WebComponents;
-    if (scope && scope.flush) {
-      scope.flush();
+    var scope = null;
+    if (window.Polymer && window.Polymer.dom && window.Polymer.dom.flush) {
+      // Polymer 0.8+
+      scope = window.Polymer.dom;
+    } else if (window.Polymer && window.Polymer.flush) {
+      // Polymer 0.5
+      scope = window.Polymer;
+    } else if (window.WebComponents && window.WebComponents.flush) {
+      scope = window.WebComponents;
     }
+    if (scope) scope.flush();
 
     // Ensure that we are creating a new _task_ to allow all active microtasks to
     // finish (the code you're testing may be using endOfMicrotask, too).


### PR DESCRIPTION
In Polymer 1.0 no flush method gets called since Polymer.flush and WebComponents.flush are both undefined.