### PR TITLE
Fixes Polymer/web-component-tester#209

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -502,7 +502,7 @@
       'sinonjs/sinon.js',
       'sinon-chai/lib/sinon-chai.js',
       'accessibility-developer-tools/dist/js/axs_testing.js',
-      'web-component-tester/runtime-helpers/a11ySuite.js'
+      // 'web-component-tester/runtime-helpers/a11ySuite.js'
     ],
 
     /** Absolute root for client scripts. Detected in `setup()` if not set. */


### PR DESCRIPTION
Simply commenting out one line to prevent the 404 warnings reported in Polymer/web-component-tester#209 : 
`404 GET /components/web-component-tester/runtime-helpers/a11ySuite.js`