### PR TITLE
use system bower

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "express": "^4.8.5",
     "findup-sync": "^0.2.1",
     "glob": "^4.0.6",
+    "global-modules": "^0.2.0",
     "lodash": "^3.0.1",
     "nomnom": "^1.8.1",
     "resolve": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   },
   "dependencies": {
     "async": "^0.9.0",
-    "bower": "^1.4.1",
     "chalk": "^1.1.1",
     "cleankill": "^1.0.0",
     "express": "^4.8.5",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -7,17 +7,28 @@
  * Code distributed by Google as part of the polymer project is also
  * subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
  */
-var bower  = require('bower');
 var path   = require('path');
 
-process.chdir(path.dirname(__dirname));
-console.log('Fetching bower dependencies for the WCT client to', path.join(process.cwd(), 'bower_components'));
-bower.commands.install(null, [], {}, {})
-    .on('end', function(installed) {
-      console.log('Fetched bower packages:', Object.keys(installed).join(', '));
-    })
-    .on('error', function(error) {
-      console.log('Failed to fetch bower dependencies:', error.stack);
-      console.log('');
-      console.log('WCT install will continue, but you may need to manually provide browser dependencies (mocha, chai, etc)');
-    });
+function fail(error) {
+  console.log('Failed to fetch bower dependencies:', error.stack);
+  console.log('');
+  console.log('WCT install will continue, but you may need to manually provide browser dependencies (mocha, chai, etc)');
+}
+
+try {
+  var globalDir = require('global-modules');
+
+  console.log('Using system bower to install browser dependencies');
+  var bower  = require(path.join(globalDir, 'bower'));
+
+  process.chdir(path.dirname(__dirname));
+
+  console.log('Fetching bower dependencies for the WCT client to', path.join(process.cwd(), 'bower_components'));
+  bower.commands.install(null, [], {}, {})
+  .on('end', function(installed) {
+    console.log('Fetched bower packages:', Object.keys(installed).join(', '));
+  })
+  .on('error', fail);
+} catch(e) {
+  fail(e);
+}


### PR DESCRIPTION
Drop bower as a requirement and use the system bower instead.
If no system bower is installed, warn the user that stuff might not work.

Fixes #217