### PR TITLE
Check if the replaced instanceTemplate needs to be restored before restoring

### DIFF
--- a/browser/mocha/replace.js
+++ b/browser/mocha/replace.js
@@ -54,7 +54,9 @@ extendInterfaces('replace', function(context, teardown) {
         // After each test...
         teardown(function() {
           // Restore the stubbed version of `Polymer.Base.instanceTemplate`:
-          Polymer.Base.instanceTemplate.restore();
+          if (Polymer.Base.instanceTemplate.isSinonProxy) {
+            Polymer.Base.instanceTemplate.restore();
+          };
         });
       }
     };

--- a/browser/mocha/replace.js
+++ b/browser/mocha/replace.js
@@ -56,7 +56,7 @@ extendInterfaces('replace', function(context, teardown) {
           // Restore the stubbed version of `Polymer.Base.instanceTemplate`:
           if (Polymer.Base.instanceTemplate.isSinonProxy) {
             Polymer.Base.instanceTemplate.restore();
-          };
+          }
         });
       }
     };


### PR DESCRIPTION
Having two tests back-to-back in TDD mode fails because the teardown step gets executed twice.
This simple fix prevents us from trying to restore an element that has already been restored.

Here's how to get a failing test. I wasn't sure how to *not* use polymer (which seems to be the norm in your tests), otherwise I would'a plopped this in the PR.

    <!doctype html>
    <html>
    <head>
      <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">

      <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
      <script src="../../bower_components/web-component-tester/browser.js"></script>
      <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
      <link rel="import" href="../../bower_components/polymer/polymer.html">

    </head>
    <body>
      <test-fixture id="basic">
        <template>
          <r-loader></r-loader>
        </template>
      </test-fixture>
    <script>
      Polymer({ is: 'r-loader'});
      Polymer({ is: 'r-loader-stub'});

      suite('simple test', function() {
        setup(function() {
          replace('r-loader').with('r-loader-stub');
          element = fixture('basic');
        })

        test('test one', function() {
          assert.equal(element.textContent, '');
        });

        test('test two passes, but then 2nd teardown fails', function() {
          assert.equal(element.textContent, '');
        });
      });
    </script>
    </body>
    </html>
