### PR TITLE
Only restore stubs if they are actually sinon proxies.

### DIFF
--- a/browser/mocha/stub.js
+++ b/browser/mocha/stub.js
@@ -36,7 +36,9 @@ extendInterfaces('stub', function(context, teardown) {
       // For all of the keys in the implementation we stubbed..
       keys.forEach(function(key) {
         // Restore the stub:
-        proto[key].restore();
+        if (proto[key].isSinonProxy) {
+          proto[key].restore();
+        }
       });
     });
   };


### PR DESCRIPTION
This is is the same problem as 

https://github.com/Polymer/web-component-tester/pull/251

Just a quick fix.