### PR TITLE
Fix broken reference to test-fixture repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "sinon-chai": "^2.6.0",
     "socket.io": "^1.3.7",
     "stacky": "^1.3.1",
-    "test-fixture": "github:PolymerElements/test-fixture",
+    "test-fixture": "PolymerElements/test-fixture",
     "wd": "^0.3.8"
   },
   "optionalDependencies": {


### PR DESCRIPTION
I'm on Windows 10 with npm 1.4.6, and wct won't install for me.  As best I can tell from the [npm documentation](https://docs.npmjs.com/files/package.json), the test-fixture dependency is specified incorrectly.  This PR fixes that.