### PR TITLE
Fix broken links to Selenium SafariDriver

### DIFF
--- a/runner/browserrunner.js
+++ b/runner/browserrunner.js
@@ -87,7 +87,7 @@ BrowserRunner.prototype._init = function _init(error, sessionId) {
         if (data.value && data.value.message && /Failed to connect to SafariDriver/i.test(data.value.message)) {
           error = 'Until Selenium\'s SafariDriver supports Safari 6.2+, 7.1+, & 8.0+, you must\n' +
                   'manually install it. Follow the steps at:\n' +
-                  'https://code.google.com/p/selenium/issues/detail?id=7933#c23';
+                  'https://github.com/SeleniumHQ/selenium/wiki/SafariDriver#getting-started';
         }
       } catch (error) {
         // Show the original error.

--- a/runner/config.js
+++ b/runner/config.js
@@ -63,7 +63,7 @@ function defaults() {
     // each browser specified in `activeBrowsers`). A handy place to hang common
     // configuration.
     //
-    // Selenium: https://code.google.com/p/selenium/wiki/DesiredCapabilities
+    // Selenium: https://github.com/SeleniumHQ/selenium/wiki/DesiredCapabilities
     // Sauce:    https://docs.saucelabs.com/reference/test-configuration/
     browserOptions: {},
     // The plugins that should be loaded, and their configuration.


### PR DESCRIPTION
wct's SafariDriver help message points to a code.google.com page that no longer exists. This patch updates the message with links to the corresponding GitHub wiki pages.