### PR TITLE
Log the referer in debug mode

### DIFF
--- a/runner/webserver.js
+++ b/runner/webserver.js
@@ -108,7 +108,8 @@ module.exports = function(wct) {
 
       // Debugging information for each request.
       app.use(function(request, response, next) {
-        wct.emit('log:debug', chalk.magenta(request.method), request.url);
+        var msg = request.url + ' (' + request.header('referer') + ')';
+        wct.emit('log:debug', chalk.magenta(request.method), msg);
         next();
       });
 


### PR DESCRIPTION
I'm currently trying to debug a rather big set of tests, which are failing due to inconsistent paths under which polymer is imported.

The verbose output of WCT isn't quite enough for that - while I can see the wrong requests, I cannot see where these come from. This PR adds the referer header to the debug output, which helps. I'm not sure whether there is any method to translate the URL back to the local path, which would be even more awesome :)