### PR TITLE
Make wct.conf.json a dotfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,7 +90,7 @@
 
 * WCT now always generates an index when run via the command line.
 
-* `wct.conf.json` can be used as an alternative to `wct.conf.js`.
+* `.wct.conf.json` can be used as an alternative to `wct.conf.js`.
 
 ## 3.0.0-3.0.6
 

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ you based on the suites you ask it to load._
 # Configuration
 
 The `wct` command line tool will pick up custom configuration from a
-`wct.conf.json` file located in the root of your project. It should export the
+`.wct.conf.json` file located in the root of your project. It should export the
 custom configuration:
 
 ```js
@@ -202,7 +202,7 @@ See [`runner/config.js`](runner/config.js) for the canonical reference of
 configuration properties.
 
 You can also specify global defaults (such as `sauce.username`, etc) via a
-config file located at `~/wct.conf.json`.
+config file located at `~/.wct.conf.json`.
 
 ## Plugins
 
@@ -286,7 +286,7 @@ Inside your test code (before `browser.js` is loaded):
 ```
 
 Alternatively, you can specify these options via the `clientOptions`
-key in `wct.conf.json`.
+key in `.wct.conf.json`.
 
 A reference of the default configuration can be found at
 [browser/config.js](browser/config.js).
@@ -356,7 +356,7 @@ module.exports = function(context, pluginOptions, plugin) {
 ```
 
 The plugin can subscribe to hooks via the [`Context`](runner/context.js)
-object. Any options (via wct.conf.json or command line) are merged into
+object. Any options (via .wct.conf.json or command line) are merged into
 `pluginOptions`. And, `plugin` is the instance of [`Plugin`](runner/plugin.js)
 for the plugin.
 

--- a/runner/config.js
+++ b/runner/config.js
@@ -17,7 +17,7 @@ var serveWaterfall = require('serve-waterfall');
 var paths = require('./paths');
 
 var HOME_DIR       = path.resolve(process.env.HOME || process.env.HOMEPATH || process.env.USERPROFILE);
-var JSON_MATCHER   = 'wct.conf.json';
+var JSON_MATCHER   = '.wct.conf.json';
 var CONFIG_MATCHER = 'wct.conf.*';
 var WCT_ROOT       = path.resolve(__dirname, '..');
 
@@ -91,7 +91,7 @@ function defaults() {
     //     }
     //
     registerHooks: function(wct) {},
-    // Whether `wct.conf.*` is allowed, or only `wct.conf.json`.
+    // Whether `wct.conf.*` is allowed, or only `.wct.conf.json`.
     //
     // Handy for CI suites that want to be locked down.
     enforceJsonConf: false,


### PR DESCRIPTION
What about making `wct.conf.json` a dotfile?

It's just a config ile, and in most of projects it's not a vital one. 

It will fall gently into bower's default ignores, and require even less boilerplate for new custom/Polymer element.
