### PR TITLE
Add quiet CLI option

### DIFF
--- a/runner/clireporter.js
+++ b/runner/clireporter.js
@@ -59,12 +59,14 @@ function CliReporter(emitter, stream, options) {
     done();
   }.bind(this));
 
-  emitter.on('log:info',  this.log.bind(this));
-  emitter.on('log:warn',  this.log.bind(this, chalk.yellow));
   emitter.on('log:error', this.log.bind(this, chalk.red));
 
-  if (this.options.verbose) {
-    emitter.on('log:debug', this.log.bind(this, chalk.dim));
+  if (!this.options.quiet) {
+    emitter.on('log:warn',  this.log.bind(this, chalk.yellow));
+    emitter.on('log:info',  this.log.bind(this));
+    if (this.options.verbose) {
+      emitter.on('log:debug', this.log.bind(this, chalk.dim));
+    }
   }
 
   emitter.on('browser-init', function(browser, stats) {

--- a/runner/config.js
+++ b/runner/config.js
@@ -33,6 +33,8 @@ function defaults() {
     ttyOutput:   undefined,
     // Spew all sorts of debugging messages.
     verbose:     false,
+    // Silence output
+    quiet:     false,
     // Display test results in expanded form. Verbose implies expanded.
     expanded:    false,
     // The on-disk path where tests & static files should be served from. Paths
@@ -157,7 +159,11 @@ var ARG_CONFIG = {
     flag:      true,
   },
   verbose: {
-    help:      'Log all the things.',
+    help:      'Turn on debugging output.',
+    flag:      true,
+  },
+  quiet: {
+    help:      'Silence output.',
     flag:      true,
   },
   simpleOutput: {


### PR DESCRIPTION
WCT is using its own logger, so it's going to be a little work to move off of it. Luckily theres some good stuff in here that we can bring into plylog when the time comes.

This work just adds support for the quiet option in addition to the already-supported verbose option.

/cc @justinfagnani 