### PR TITLE
Let fixture.js provide a helpful error if the fixture can not be found

### DIFF
--- a/browser/mocha/fixture.js
+++ b/browser/mocha/fixture.js
@@ -14,6 +14,10 @@ extendInterfaces('fixture', function(context, teardown) {
 
     // Find the test-fixture with the provided ID and create it, returning
     // the results:
-    return document.getElementById(fixtureId).create(model);
+    var fixture = document.getElementById(fixtureId);
+    if (!fixture) {
+      throw 'Could not find fixture with ID <' + fixtureId + '>'; 
+    }
+    return fixture.create(model);
   };
 });


### PR DESCRIPTION
If you fat-finger the fixture ID it gives you a nasty 'Cannot call create on undefined' (or something similar) which requires additional debugging.
