### PR TITLE
Share websocket connection in browser.js

### DIFF
--- a/browser/index.js
+++ b/browser/index.js
@@ -75,6 +75,11 @@ document.addEventListener('DOMContentLoaded', function() {
     var reporter = new MultiReporter(childSuites.length + 1, reportersToUse, parent);
     WCT._reporter = reporter; // For environment/compatibility.js
 
+    // Publish socket to allow communication for other parties.
+    if (socket) {
+      WCT.share.socket = socket;
+    }
+
     // We need the reporter so that we can report errors during load.
     suites.loadJsSuites(reporter, function(error) {
       // Let our parent know that we're about to start the tests.

--- a/test/fixtures/integration/share-websocket/golden.json
+++ b/test/fixtures/integration/share-websocket/golden.json
@@ -1,0 +1,13 @@
+{
+  "passing": 0,
+  "pending": 0,
+  "failing": 0,
+  "status": "complete",
+  "tests": {
+    "test/": {
+      "wct socket exist": {
+        "state": "passing"
+      }
+    }
+  }
+}

--- a/test/fixtures/integration/share-websocket/test/index.html
+++ b/test/fixtures/integration/share-websocket/test/index.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<html>
+
+<head>
+    <meta charset="utf-8">
+    <script src="../../../browser.js"></script>
+</head>
+
+<body>
+<script>
+    test('wct socket exist', function () {
+        const wctShare = WCT.share;
+        assert.deepEqual(('socket' in wctShare), true);
+    });
+</script>
+</body>
+
+</html>

--- a/test/fixtures/integration/share-websocket/test/index.html
+++ b/test/fixtures/integration/share-websocket/test/index.html
@@ -1,18 +1,15 @@
 <!doctype html>
 <html>
-
-<head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-</head>
-
-<body>
-<script>
-    test('wct socket exist', function () {
-        const wctShare = WCT.share;
-        assert.deepEqual(('socket' in wctShare), true);
-    });
-</script>
-</body>
-
+    <head>
+        <meta charset="utf-8">
+        <script src="../../../browser.js"></script>
+    </head>
+    <body>
+        <script>
+            test('wct socket exist', function () {
+                const wctShare = WCT.share;
+                assert.deepEqual(('socket' in wctShare), true);
+            });
+        </script>
+    </body>
 </html>


### PR DESCRIPTION
**Problem and goal**: During preparing the plugin that takes a screenshot during tests or plugin that detect DOM leak we encountered the need to achieve a communication between the browser and the host.

**Solution:** Share WebSocket connection in browser.js to allow sending custom messages. I've chosen this solution because it can be very useful, when we want to perform an action on the host during a test.

**Example of use in plugin:**

Browser site:
(function Screenshot() {
    ...
socket = window.WCT.share.socket;
socket.socket.on('confirm-screenshot', function (data) {
    ...
});
    ...
socket.emitEvent('screenshot', { fileName: fileName, .... });
    ...
}
})();

Host site:
function Screenshot(emitter, pluginOptions) {
    ...
    emitter.on('screenshot', makeScreenshot.bind(this));
}
