### PR TITLE
Ensure fail events outside of the scope of a test result in a failure.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1718,6 +1718,12 @@ CLISocket.prototype.observe = function observe(runner) {
     });
   }.bind(this));
 
+  runner.on('fail', function(test, err) {
+    if (err.uncaught || test.type == 'hook') {
+      runner.emit('test end', test);
+    }
+  }.bind(this));
+
   runner.on('childRunner start', function(childRunner) {
     this.emitEvent('sub-suite-start', childRunner.share);
   }.bind(this));

--- a/test/fixtures/integration/setup-throws/index.html
+++ b/test/fixtures/integration/setup-throws/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <script src="../../../../browser.js"></script>
+  </head>
+  <body>
+    <script>
+      WCT.loadSuites(['tests.js']);
+    </script>
+  </body>
+</html>

--- a/test/fixtures/integration/setup-throws/tests.js
+++ b/test/fixtures/integration/setup-throws/tests.js
@@ -1,0 +1,8 @@
+setup(function() {
+  throw "Failed";
+});
+
+// Don't expect this test to be run due to setup failing.
+test('not run test', function() {
+  assert.isTrue(false);
+});

--- a/test/integration/browser.js
+++ b/test/integration/browser.js
@@ -380,6 +380,15 @@ function runsAllIntegrationSuites() {
 
   });
 
+  runsIntegrationSuite('setup-throws', function() {
+
+    it('fails', function() {
+      assertFailed(this);
+      assertStats(this, 0, 0, 0, 'complete');
+    });
+
+  });
+
 }
 
 // Environments


### PR DESCRIPTION
Without this the failures would be visible in the HTML UI, but running
on the command line wouldn't print any failures.

Note using err.uncaught and test.type == 'hook' comes from mocha, see https://github.com/mochajs/mocha/commit/34abc7180019640dd5735be4fa2906e6410e434e for a related fix. This fixes issue #350.
