### PR TITLE
test() function must reject when any test fails.

### DIFF
--- a/runner/steps.ts
+++ b/runner/steps.ts
@@ -162,7 +162,7 @@ function runBrowsers(context: Context) {
       await context.emitHook('cleanup');
 
       if (error) {
-        throw error;
+        throw new Error(error);
       }
     }())
   };

--- a/runner/steps.ts
+++ b/runner/steps.ts
@@ -161,7 +161,9 @@ function runBrowsers(context: Context) {
       // TODO(nevir): Better rationalize run-end and hook.
       await context.emitHook('cleanup');
 
-      return error;
+      if (error) {
+        throw error;
+      }
     }())
   };
 }

--- a/test/integration/browser.ts
+++ b/test/integration/browser.ts
@@ -444,7 +444,7 @@ function runsIntegrationSuite(
       try {
         await test(context);
       } catch (error) {
-        testContext.testRunnerError = error;
+        testContext.testRunnerError = error.message;
       }
     });
 

--- a/test/integration/browser.ts
+++ b/test/integration/browser.ts
@@ -44,6 +44,7 @@ function assertPassed(context: TestContext) {
 
 function assertFailed(context: TestContext, expectedError: string) {
   expect(context.runError).to.eq(expectedError);
+  expect(context.testRunnerError).to.be.eq(expectedError);
   expect(context.errors).to.deep.equal(repeatBrowsers(context, expectedError));
 }
 


### PR DESCRIPTION
Fixes #375 

In the future we should have an integration test that actually shells out to `wct` and we should assert on the exit code. The integration test cleanup needs to land first though in #374