### PR TITLE
Add empty callback to prepare:webserver

### DIFF
--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -140,7 +140,7 @@ export function webserver(wct: Context): void {
 
     // At this point, we allow other plugins to hook and configure the
     // webserver as they please.
-    await wct.emitHook('prepare:webserver', app);
+    await wct.emitHook('prepare:webserver', app, () => { });
 
     // Serve up all the static assets.
     app.use(serveWaterfall(wsOptions.pathMappings, {

--- a/test/unit/context.ts
+++ b/test/unit/context.ts
@@ -59,6 +59,19 @@ describe('Context', () => {
       expect(plugins).to.have.members(['local']);
     });
 
+    describe('hook handlers with only one argument', () => {
+      it('are passed the "done" callback function instead of the argument passed to emitHook', async() => {
+        const context = new Context();
+          context.hook('foo', function(arg1: any) {
+            expect(arg1).to.not.eq('hookArg');
+            // arg1 has been replaced with 'done'
+            arg1();
+        });
+
+        await context.emitHook('foo', 'hookArg');
+      });
+    });
+
     describe('hook handlers written to call callbacks', () => {
       it('passes additional arguments through', async() => {
         const context = new Context();


### PR DESCRIPTION
This fixes problem where express middleware is not passed to hooks subscribed to perpare:webserver.

Fixes #373 and #383 

I would prefer to remove the callback option all together but that would break the wct-sauce dependency, which uses callbacks
