### PR TITLE
fix problem with globs not de-duplicating file matches on Windows OS …

### DIFF
--- a/runner/paths.ts
+++ b/runner/paths.ts
@@ -41,7 +41,9 @@ async function unglob(baseDir: string, patterns: string[]):
       for (const pattern of patterns) {
         strs.push(await pGlob(String(pattern), {cwd: baseDir, root: baseDir}));
       }
-      return _.union(_.flatten(strs));
+
+      // for non-POSIX support, replacing path separators
+      return _.union(_.flatten(strs)).map((str) => str.replace(/\//g, path.sep));
     }
 
 /**

--- a/test/unit/paths.ts
+++ b/test/unit/paths.ts
@@ -23,6 +23,9 @@ describe('paths', function() {
 
     async function expectExpands(patterns: string[], expected: string[]) {
       const actual = await paths.expand(baseDir, patterns);
+
+      // for non-POSIX support 
+      expected = expected.map((str) => str.replace(/\//g, path.sep));
       expect(actual).to.have.members(expected);
     }
 


### PR DESCRIPTION
paths .expand doesn't de-duplicate on Windows

This is because the glob package doesn't accept forward-slash delimiters but node path will use the underlying OS' delimiter. 

(#404)
