### PR TITLE
signal vscode to use local typescript version

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,4 +15,6 @@
     "browser.js": true,
     "browser.js.map": true
   }
+,
+"typescript.tsdk": "./node_modules/typescript/lib"
 }


### PR DESCRIPTION
otherwise vscode gets upset and asks you which typescript version to use everytime you open the project.

/cc @rictic @justinfagnani 