### PR TITLE
Fix emitHook for 2-arg calls without a callback.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 * `webserver.webRunnerPath`, `webserver.host`, `webserver.webRunnerContent`, and `webserver.urlPrefix`, `webserver.staticContent` were internal properties that were exposed on the `config` object. They have been refactored and their replacement has been prefixed with an underscore to clarify that they're internal implementation details.
 
+### Fixed
+* Fixed #373 and #383 which were caused by `emitHook` not handling argumnts correctly.
+
 ## 5.0.0
 * Mocha upgraded to `v3.1.2`. This shouldn't require any new code, but make sure your tests still pass as there were some more subtle changes made to Mocha behavior for v3 (Add IE7 support, update dependencies). See https://github.com/mochajs/mocha/pull/2350 for more info.
 

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   ],
   "scripts": {
     "lint": "gulp lint",
-    "build": "gulp build",
+    "build": "tsc",
     "test": "tsc && gulp test",
     "prepublish": "gulp prepublish",
     "test:watch": "watch 'gulp test:unit' runner/ browser/ bin/ test/ tasks/",

--- a/runner/context.ts
+++ b/runner/context.ts
@@ -101,34 +101,33 @@ export class Context extends events.EventEmitter {
    */
   emitHook(
       name: 'prepare:webserver', app: Express.Application,
-      done: (err?: any) => void): Promise<void>;
-  emitHook(name: 'configure', done: (err?: any) => void): Promise<void>;
-  emitHook(name: 'prepare', done: (err?: any) => void): Promise<void>;
-  emitHook(name: 'cleanup', done: (err?: any) => void): Promise<void>;
-  emitHook(name: string, done: (err?: any) => void): Promise<void>;
+      done?: (err?: any) => void): Promise<void>;
+  emitHook(name: 'configure', done?: (err?: any) => void): Promise<void>;
+  emitHook(name: 'prepare', done?: (err?: any) => void): Promise<void>;
+  emitHook(name: 'cleanup', done?: (err?: any) => void): Promise<void>;
+  emitHook(name: string, done?: (err?: any) => void): Promise<void>;
   emitHook(name: string, ...args: any[]): Promise<void>;
-  async emitHook(name: string, done: (err?: any) => void): Promise<void> {
+
+  async emitHook(name: string /*, ...args: any[]*/): Promise<void> {
     this.emit('log:debug', 'hook:', name);
+
+    // TODO(justinfagnani): remove and uncomment ...args when we drop node 4
+    const args = Array.from(arguments).slice(1);
 
     const hooks = (this._hookHandlers[name] || []);
     type BoundHook = (cb: (err: any) => void) => (void|Promise<any>);
     let boundHooks: BoundHook[];
-    if (arguments.length > 2) {
-      done = arguments[arguments.length - 1];
-      let argsEnd = arguments.length - 1;
-      if (!(done instanceof Function)) {
-        done = (_e) => {};
-        argsEnd = arguments.length;
-      }
-      const hookArgs = Array.from(arguments).slice(1, argsEnd);
-      boundHooks = hooks.map(function(hook) {
-        return hook.bind.apply(hook, [null].concat(hookArgs));
-      });
+    let done: (err?: any) => void = (_err: any) => {};
+    let argsEnd = args.length - 1;
+    if (args[argsEnd] instanceof Function) {
+      done = args[argsEnd];
+      argsEnd = argsEnd--;
     }
+    const hookArgs = args.slice(0, argsEnd + 1);
+    boundHooks = hooks.map((hook) => hook.bind.apply(hook, [null].concat(hookArgs)));
     if (!boundHooks) {
       boundHooks = <any>hooks;
     }
-    done = done || ((_e) => {});
 
     // A hook may return a promise or it may call a callback. We want to
     // treat hooks as though they always return promises, so this converts.

--- a/test/unit/context.ts
+++ b/test/unit/context.ts
@@ -59,6 +59,17 @@ describe('Context', () => {
       expect(plugins).to.have.members(['local']);
     });
 
+    describe('hook handlers with non-callback second argument', async() => {
+      it('are passed the "done" callback function instead of the argument passed to emitHook', async() => {
+        const context = new Context();
+        context.hook('foo', function(arg1: any, done: () => void) {
+          expect(arg1).to.eq('hookArg');
+          done();
+        });
+        await context.emitHook('foo', 'hookArg');
+      });
+    });
+
     describe('hook handlers written to call callbacks', () => {
       it('passes additional arguments through', async() => {
         const context = new Context();


### PR DESCRIPTION
Fixes #373 and #383

Verified that the test fails on master and passes now.

 - [ ] CHANGELOG.md has been updated

