### PR TITLE
Look more places for client version.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,9 @@
     "*",
     "!/data/*",
     "!/browser.js",
-    "!/browser.js.map"
+    "!/browser.js.map",
+    "!/package.json",
+    "!/bower.json"
   ],
   "keywords": [
     "browser",


### PR DESCRIPTION
Also publish bower.json and package.json to bower.

Fixes #447

 - [x] CHANGELOG.md has not been updated, this is a bugfix of an unreleased feature.