### PR TITLE
Use polyserve's ESNext -> ES5 compilation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@
 
 ### Removed
 
-* `webserver.webRunnerPath`, `webserver.host`, `webserver.webRunnerContent`, and `webserver.urlPrefix`, `webserver.staticContent` were internal properties that were exposed on the `config` object. They have been refactored and their replacement has been prefixed with an underscore to clarify that they're internal implementation details.
+* `webserver.webRunnerPath`, `webserver.webRunnerContent`, and `webserver.urlPrefix`, `webserver.staticContent` were internal properties that were exposed on the `config` object. They have been refactored and their replacement has been prefixed with an underscore to clarify that they're internal implementation details.
 * `test-fixture`-mocha integration is no longer included in web-component-tester by default. See [here](https://github.com/PolymerElements/test-fixture#even-simpler-usage-in-mocha) for `test-fixture`-mocha integration.
 
 ### Fixed

--- a/runner/config.ts
+++ b/runner/config.ts
@@ -54,6 +54,9 @@ export interface Config {
     // determined at runtime if none is provided.
     port: number;
 
+    // The hostname used when generating URLs for the webdriver client.
+    hostname: string;
+
     _generatedIndexContent?: string;
     _servers?: {variant: string, url: string}[];
   };
@@ -63,11 +66,13 @@ export interface Config {
   sauce?: {};
   remote?: {};
   origSuites?: string[];
-  /** A deprecated option */
-  browsers?: Browser[]|Browser;
+  compile?: 'auto'|'always'|'never';
   skipCleanup?: boolean;
   simpleOutput?: boolean;
   skipUpdateCheck?: boolean;
+
+  /** A deprecated option */
+  browsers?: Browser[]|Browser;
 }
 
 // The full set of options, as a reference.
@@ -101,6 +106,8 @@ export function defaults(): Config {
     clientOptions: {
       root: '/components/',
     },
+    compile: 'auto',
+
     // Webdriver capabilities objects for each browser that should be run.
     //
     // Capabilities can also contain a `url` value which is either a string URL
@@ -153,6 +160,7 @@ export function defaults(): Config {
       // The port that the webserver should run on. A port will be determined at
       // runtime if none is provided.
       port: undefined,
+      hostname: 'localhost',
     },
   };
 }
@@ -216,6 +224,12 @@ const ARG_CONFIG = {
   },
   // Managed by supports-color; let's not freak out if we see it.
   color: {flag: true},
+
+  compile: {
+    help: 'Whether to compile ES2015 down to ES5. ' +
+        'Options: "always", "never", "auto". Auto means that we will ' +
+        'selectively compile based on the requesting user agent.'
+  },
 
   // Deprecated
 

--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -157,8 +157,9 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
     // Serve up project & dependencies via polyserve
     const polyserveResult = await startServers({
       root: options.root,
-      headers: DEFAULT_HEADERS, packageName,
-      additionalRoutes: additionalRoutes,
+      compile: options.compile,
+      hostname: options.webserver.hostname,
+      headers: DEFAULT_HEADERS, packageName, additionalRoutes,
     });
     let servers: Array<MainlineServer|VariantServer>;
 

--- a/test/fixtures/integration/compilation/golden.json
+++ b/test/fixtures/integration/compilation/golden.json
@@ -1,0 +1,13 @@
+{
+  "passing": 1,
+  "pending": 0,
+  "failing": 0,
+  "status": "complete",
+  "tests": {
+    "test/": {
+      "ES6 works": {
+        "state": "passing"
+      }
+    }
+  }
+}

--- a/test/fixtures/integration/compilation/test/index.html
+++ b/test/fixtures/integration/compilation/test/index.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <script src="../../../browser.js"></script>
+</head>
+
+<body>
+  <script>
+    test('ES6 works', function () {
+      // This doesn't work in Firefox 50, but it soon will...
+      // soon we'll need to test it with IE 11.
+      const funcs = [];
+      for (const foo of [1, 2, 3]) {
+        funcs.push(() => foo);
+      }
+
+      assert.deepEqual(funcs.map(f => f()), [1, 2, 3]);
+    });
+  </script>
+</body>
+
+</html>


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

Also hook the `webserver.hostname` flag back up, as it turns out it's used.

Fixes #437

/cc @azakus 