### PR TITLE
Remove the warning about no local node_modules install of wct.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## Unreleased
 
 * Update wct-local to remove deprecation warnings on install.
+* Remove warning when running wct if it's not installed into `node_modules`.
 
 ## 6.0.0-prerelease.9 - 2017-04-19
 

--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -108,29 +108,6 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
 `);
     }
 
-    // Check that there's a wct node module.
-    const pathToWctNodeModule =
-        path.join(options.root, 'node_modules', 'web-component-tester');
-    if (!exists(pathToWctNodeModule)) {
-      console.warn(`
-    The web-component-tester node module is not installed as a dependency of
-    this project (${packageName}).
-
-    We recommend that you run this command to add it:
-        npm install --save-dev web-component-tester
-
-    or run:
-        yarn add web-component-tester --dev
-
-    Doing so will ensure that your project is in control of the version of wct
-    that your project is tested with, insulating you from any future breaking
-    changes and making your test runs more reproducible. In a future release
-    of wct this will be required.
-
-    Expected a directory to exist at: ${pathToWctNodeModule}/
-`);
-    }
-
     let hasWarnedBrowserJs = false;
     additionalRoutes.set('/browser.js', function(request, response) {
       if (!hasWarnedBrowserJs) {


### PR DESCRIPTION
`wct` is slow to install, and having a local node install of it doesn't actually buy us much. The vastly more important thing is that users have the expected client-side dependencies, as wct's server-side semantics don't change enough to make this worth the cost in installation time and hassle.

Fixes #486 

Other discussion at #444 (and one other with @cdata IIRC, though I can't find that at present).