### PR TITLE
Add `Polymer.dom.flush()` before each test.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@
 
 ### Added
 
+* Polymer.dom.flush() call in a11ySuite to ensure lazy dom is loaded
+* Added beforeEach parameter to a11ySuite
 * Added first pass of _variants_. Variants different configurations of testing the same code.
   * Add support for _variant dependencies_.
     * wct already supports loading dependencies from your `bower_components` directory, mapping them to `../` in your code. You can now add variant dependency directories named like `bower_components-foo`. When these are detected, tests will then run separately for each such dependency directory, mapping `../` appropriately. See README for more details.
@@ -22,6 +24,8 @@
 * `webserver.webRunnerPath`, `webserver.webRunnerContent`, and `webserver.urlPrefix`, `webserver.staticContent` were internal properties that were exposed on the `config` object. They have been refactored and their replacement has been prefixed with an underscore to clarify that they're internal implementation details.
 
 ### Fixed
+
+* Fixed #392
 * Fixed #373 and #383 which were caused by `emitHook` not handling arguments correctly.
 * Fixed error log message for loading WCT config
 

--- a/README.md
+++ b/README.md
@@ -90,10 +90,15 @@ suite('AwesomeLib', function() {
  });
  ```
 
-### a11ySuite
+### a11ySuite(fixureId, ignoredTests, beforeEach)
+|Parameter|Type|Descrption|
+|---|---|---|
+|fixtureId|String|ID of the fixture to instantiate and test|
+|ignoredTests|Array<string> (optional)|Tests to ignore. <br />Test names are found [here](https://github.com/GoogleChrome/accessibility-developer-tools/blob/master/dist/js/axs_testing.js) as calls to axs.AuditRules.addRule()|
+|beforeEach|Function (optional)|Called before each test is run|
 
 `a11ySuite` provides an simple way to run accessibility-developer-tools' high quality accessibility
-audits when given a `test-fixture`.
+audits when given a `test-fixture`. 
 The `a11ySuite` will show all the audit results via the standard Mocha test output.
 ```html
 <test-fixture id="NoLabel">

--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ suite('AwesomeLib', function() {
 |beforeEach|Function (optional)|Called before each test is run|
 
 `a11ySuite` provides an simple way to run accessibility-developer-tools' high quality accessibility
-audits when given a `test-fixture`. 
+audits when given a `test-fixture`.
 The `a11ySuite` will show all the audit results via the standard Mocha test output.
 ```html
 <test-fixture id="NoLabel">

--- a/data/a11ySuite.js
+++ b/data/a11ySuite.js
@@ -51,13 +51,15 @@
           a11ySuite.eachTest = function() {
             // instantiate fixture
             fixtureElement.create();
-            
+
             // Make sure lazy-loaded dom is ready (eg <template is='dom-repeat'>)
             Polymer.dom.flush();
-            
+
             // If we have a beforeEach function, call it
-            if(beforeEach) beforeEach();
-            
+            if (beforeEach) {
+              beforeEach();
+            }
+
             // run audit
             var auditResults = axs.Audit.run(axsConfig);
 

--- a/data/a11ySuite.js
+++ b/data/a11ySuite.js
@@ -26,8 +26,9 @@
           *
           * @param {String} fixtureId ID of the fixture element in the document to use
           * @param {Array?} ignoredRules Array of rules to ignore for this suite
+          * @param {Function?} beforeEach Function to be called before each test to ensure proper setup
           */
-        context.a11ySuite = function(fixtureId, ignoredRules) {
+        context.a11ySuite = function(fixtureId, ignoredRules, beforeEach) {
           // capture a reference to the fixture element early
           var fixtureElement = document.getElementById(fixtureId);
           if (!fixtureElement) {
@@ -50,7 +51,13 @@
           a11ySuite.eachTest = function() {
             // instantiate fixture
             fixtureElement.create();
-
+            
+            // Make sure lazy-loaded dom is ready (eg <template is='dom-repeat'>)
+            Polymer.dom.flush();
+            
+            // If we have a beforeEach function, call it
+            if(beforeEach) beforeEach();
+            
             // run audit
             var auditResults = axs.Audit.run(axsConfig);
 


### PR DESCRIPTION
 - This is a follow-up to https://github.com/Polymer/web-component-tester/pull/493
 - [x] CHANGELOG.md has been updated
 - @lukeschaefer's original PR description:
> As per issue #392, parts of the page may be missing while a11ySuite runs, since `Polymer.dom.flush()` is never called.
>
>Without Polymer.dom.flush, fixtures with elements containing dom-repeat or dom-if templates would not be fully loaded. In many cases, this results in running the test suite on only a fragment of the page, missing possible errors. In few cases, it would trigger possible errors, for example:
>
> ```html
> <div role='radiogroup'>
>   <template is='dom-repeat'>
>      <ul role='radio'>Button</ul>
>   </template> 
> </div>
> ```
> The test suite would incorrectly think the radiogroup had no role='radio' children.
>
> Also, this adds in a beforeEach function that can be passed in, allowing any extra setup to run before each test.
