### PR TITLE
Ensure that express and done are getting returned in `prepare:webserver`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 6.0.0-prerelease.9 - 2017-04-19
 
 * The default `waitFor` doesn't rely on `HTMLImports.whenReady` or `Polymer.whenReady` timings, but only waits for the `WebComponentsReady` event to be fired. For a different wait time, set `WCT = { waitFor: function(cb){ cb(); }}`.
-m
+
 ## 6.0.0-prerelease.8 - 2017-04-13
 
 * [BREAKING] Dropped support for node v4, added support for node v8. See our [node version support policy](https://www.polymer-project.org/2.0/docs/tools/node-support) for details.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased - 2017-05-24
+
+* Fix what `prepare:webserver` was returning. Ensuring it was returning both a done() callback and the Express server object.
+
 ## 6.0.0 - 2017-05-15
 
 * Major changes:
@@ -25,7 +29,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## 6.0.0-prerelease.9 - 2017-04-19
 
 * The default `waitFor` doesn't rely on `HTMLImports.whenReady` or `Polymer.whenReady` timings, but only waits for the `WebComponentsReady` event to be fired. For a different wait time, set `WCT = { waitFor: function(cb){ cb(); }}`.
-
+m
 ## 6.0.0-prerelease.8 - 2017-04-13
 
 * [BREAKING] Dropped support for node v4, added support for node v8. See our [node version support policy](https://www.polymer-project.org/2.0/docs/tools/node-support) for details.

--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -175,7 +175,9 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
     // At this point, we allow other plugins to hook and configure the
     // webservers as they please.
     for (const server of servers) {
-      await wct.emitHook('prepare:webserver', server.app);
+      await wct.emitHook('prepare:webserver', server.app, function() {
+        return Promise.resolve();
+      });
     }
 
     options.webserver._servers = servers.map(s => {


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [X] CHANGELOG.md has been updated
