### PR TITLE
Fix styling for html and body, so that unnecessary scrollbars don't appear anymore.

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -871,7 +871,9 @@ var style = document.createElement('style');
 style.textContent = 'html, body {' +
                     '  position: relative;' +
                     '  height: 100%;' +
-                    '  width:  100%;' +
+                    '  width: 100%;' +
+                    '  margin: 0;' +
+                    '  padding: 0;' +
                     '  min-width: 900px;' +
                     '}' +
                     '#mocha, #subsuites {' +

--- a/browser/reporters/html.js
+++ b/browser/reporters/html.js
@@ -31,7 +31,8 @@ var style = document.createElement('style');
 style.textContent = 'html, body {' +
                     '  position: relative;' +
                     '  height: 100%;' +
-                    '  width:  100%;' +
+                    '  margin: 0;' +
+                    '  padding: 0;' +
                     '  min-width: 900px;' +
                     '}' +
                     '#mocha, #subsuites {' +


### PR DESCRIPTION
For example user agent styles in Chrome include body: { margin: 8px }.
Thus, html doesn't have enough space for body, and both horizontal and
vertical appear.

Scrollbars are annoying when writing screenshot tests, as if the
component takes all the available width (or/and height), scrollbars
appear on the screenshots too.

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated
