### PR TITLE
Fixes #561

### DIFF
--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "findup-sync": "^0.4.3",
     "glob": "^7.1.1",
     "lodash": "^3.0.1",
+    "deepmerge": "^1.4.4",
     "mocha": "^3.1.2",
     "multer": "^1.1.0",
     "nomnom": "^1.8.1",

--- a/runner/steps.ts
+++ b/runner/steps.ts
@@ -13,6 +13,7 @@
  */
 import * as http from 'http';
 import * as _ from 'lodash';
+import * as deepmerge from 'deepmerge';
 import * as socketIO from 'socket.io';
 
 import {BrowserRunner} from './browserrunner';
@@ -142,10 +143,10 @@ function runBrowsers(context: Context) {
     let waitFor: undefined|Promise<void> = undefined;
     for (const server of options.webserver._servers) {
       // Needed by both `BrowserRunner` and `CliReporter`.
-      const browserDef = _.clone(originalBrowserDef);
+      let browserDef = _.clone(originalBrowserDef);
       browserDef.id = id++;
       browserDef.variant = server.variant;
-      _.defaultsDeep(browserDef, options.browserOptions);
+      browserDef = deepmerge(browserDef, options.browserOptions);
 
       const runner =
           new BrowserRunner(context, browserDef, options, server.url, waitFor);


### PR DESCRIPTION
 - allows proper merge of `wct.conf.json`.browserOptions with core options
 - adds `deepmerge` dependency because lodash.defaultsDeep does not concat array values on the same key (see issue for more info)

*Please note - I was not able to run the npm tasks `test` or `build`~
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated
