### PR TITLE
Updated test fixtures for integration tests so they wouldn't trigger the deprecation warning on requesting '/browser.js'

### DIFF
--- a/test/fixtures/early-failure/test/index.html
+++ b/test/fixtures/early-failure/test/index.html
@@ -3,15 +3,15 @@
 
 <head>
   <meta charset="utf-8">
-  <script src="../../../browser.js"></script>
+  <script src="/components/web-component-tester/browser.js"></script>
 </head>
 
 <body>
   <script>
-      test('inline passing test', function() {
-        assert.equal('yes', 'yes');
-      });
-    </script>
+    test('inline passing test', function () {
+      assert.equal('yes', 'yes');
+    });
+  </script>
 </body>
 
 </html>

--- a/test/fixtures/integration/compilation/test/index.html
+++ b/test/fixtures/integration/compilation/test/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <script src="../../../browser.js"></script>
+  <script src="/components/web-component-tester/browser.js"></script>
 </head>
 
 <body>

--- a/test/fixtures/integration/components_dir/test/index.html
+++ b/test/fixtures/integration/components_dir/test/index.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script src="../../foo-element/foo-element.js"></script>
-    <script>
-      test('inline passing test', function() {
-        assert.equal(window.fooElementLoaded, 'yes');
-      });
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script src="../../foo-element/foo-element.js"></script>
+  <script>
+    test('inline passing test', function () {
+      assert.equal(window.fooElementLoaded, 'yes');
+    });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/failing/golden.json
+++ b/test/fixtures/integration/failing/golden.json
@@ -31,7 +31,7 @@
     "test/": {
       "inline failing test": [
         "expected false to be true",
-        "at index\\.html:13(:|$)"
+        "at index\\.html:15(:|$)"
       ],
       "failing test": [
         "expected false to be true",
@@ -41,7 +41,7 @@
     "test/tests.html": {
       "failing test": [
         "expected false to be true",
-        "at tests\\.html:11(:|$)"
+        "at tests\\.html:13(:|$)"
       ]
     }
   }

--- a/test/fixtures/integration/failing/test/index.html
+++ b/test/fixtures/integration/failing/test/index.html
@@ -1,17 +1,20 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites(['tests.html', 'tests.js']);
 
-      test('inline passing test', function() {});
-      test('inline failing test', function() {
-        assert.isTrue(false);
-      });
-    </script>
-  </body>
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites(['tests.html', 'tests.js']);
+
+    test('inline passing test', function () { });
+    test('inline failing test', function () {
+      assert.isTrue(false);
+    });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/failing/test/tests.html
+++ b/test/fixtures/integration/failing/test/tests.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      test('passing test', function() {});
-      test('failing test', function() {
-        assert.isTrue(false);
-      });
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    test('passing test', function () { });
+    test('failing test', function () {
+      assert.isTrue(false);
+    });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/hybrid/test/index.html
+++ b/test/fixtures/integration/hybrid/test/index.html
@@ -1,17 +1,20 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites(['tests.html', 'tests.js']);
 
-      suite('inline suite', function() {
-        test('inline nested test', function() {});
-      });
-      test('inline test', function() {});
-    </script>
-  </body>
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites(['tests.html', 'tests.js']);
+
+    suite('inline suite', function () {
+      test('inline nested test', function () { });
+    });
+    test('inline test', function () { });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/hybrid/test/tests.html
+++ b/test/fixtures/integration/hybrid/test/tests.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      suite('suite', function() {
-        test('nested test', function() {});
-      });
-      test('test', function() {});
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    suite('suite', function () {
+      test('nested test', function () { });
+    });
+    test('test', function () { });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/inline-js/test/index.html
+++ b/test/fixtures/integration/inline-js/test/index.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      suite('suite', function() {
-        test('nested test', function() {});
-      });
-      test('test', function() {});
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    suite('suite', function () {
+      test('nested test', function () { });
+    });
+    test('test', function () { });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/many-html/test/index.html
+++ b/test/fixtures/integration/many-html/test/index.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites(['one.html', 'two.html', 'three.html']);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites(['one.html', 'two.html', 'three.html']);
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/many-html/test/one.html
+++ b/test/fixtures/integration/many-html/test/one.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      suite('suite 1', function() {
-        test('nested test 1', function() {});
-      });
-      test('test 1', function() {});
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    suite('suite 1', function () {
+      test('nested test 1', function () { });
+    });
+    test('test 1', function () { });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/many-html/test/three.html
+++ b/test/fixtures/integration/many-html/test/three.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      suite('suite 3', function() {
-        test('nested test 3', function() {});
-      });
-      test('test 3', function() {});
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    suite('suite 3', function () {
+      test('nested test 3', function () { });
+    });
+    test('test 3', function () { });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/many-html/test/two.html
+++ b/test/fixtures/integration/many-html/test/two.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      suite('suite 2', function() {
-        test('nested test 2', function() {});
-      });
-      test('test 2', function() {});
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    suite('suite 2', function () {
+      test('nested test 2', function () { });
+    });
+    test('test 2', function () { });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/many-js/test/index.html
+++ b/test/fixtures/integration/many-js/test/index.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites(['one.js', 'two.js', 'three.js']);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites(['one.js', 'two.js', 'three.js']);
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/missing/test/missing.html
+++ b/test/fixtures/integration/missing/test/missing.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites(['tests.html', 'tests.js']);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites(['tests.html', 'tests.js']);
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/multiple-component_dirs/golden.json
+++ b/test/fixtures/integration/multiple-component_dirs/golden.json
@@ -7,7 +7,9 @@
       "status": "complete",
       "tests": {
         "test/": {
-          "only works with mainline components": {"state": "passing"}
+          "only works with mainline components": {
+            "state": "passing"
+          }
         }
       }
     },
@@ -18,14 +20,16 @@
       "status": "complete",
       "tests": {
         "test/": {
-          "only works with mainline components": {"state": "failing"}
+          "only works with mainline components": {
+            "state": "failing"
+          }
         }
       },
       "errors": {
         "test/": {
           "only works with mainline components": [
-              "expected 'foo' to equal 'mainline'",
-              "at index\\.html:11"
+            "expected 'foo' to equal 'mainline'",
+            "at index\\.html:13"
           ]
         }
       }
@@ -37,14 +41,16 @@
       "status": "complete",
       "tests": {
         "test/": {
-          "only works with mainline components": {"state": "failing"}
+          "only works with mainline components": {
+            "state": "failing"
+          }
         }
       },
       "errors": {
         "test/": {
           "only works with mainline components": [
-              "expected 'bar' to equal 'mainline'",
-              "at index\\.html:11"
+            "expected 'bar' to equal 'mainline'",
+            "at index\\.html:13"
           ]
         }
       }

--- a/test/fixtures/integration/multiple-component_dirs/test/index.html
+++ b/test/fixtures/integration/multiple-component_dirs/test/index.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script src="../../package/index.js"></script>
-    <script>
-      test('only works with mainline components', function() {
-        expect(window.nameOfThing).to.be.equals('mainline');
-      });
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script src="../../package/index.js"></script>
+  <script>
+    test('only works with mainline components', function () {
+      expect(window.nameOfThing).to.be.equals('mainline');
+    });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/multiple-replace/test/index.html
+++ b/test/fixtures/integration/multiple-replace/test/index.html
@@ -4,16 +4,16 @@
 <head>
   <meta charset="utf-8">
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
-  <script src="../../../browser.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
 </head>
 
 <body>
   <script>
-      WCT.loadSuites([
-        'tests.html?dom=shadow',
-        'tests.html?wc-ce=true&wc-shadydom=true',
-      ]);
-    </script>
+    WCT.loadSuites([
+      'tests.html?dom=shadow',
+      'tests.html?wc-ce=true&wc-shadydom=true',
+    ]);
+  </script>
 </body>
 
 </html>

--- a/test/fixtures/integration/multiple-replace/test/tests.html
+++ b/test/fixtures/integration/multiple-replace/test/tests.html
@@ -4,7 +4,7 @@
   <link rel="import" href="../../test-fixture/test-fixture.html">
   <script src="../../webcomponentsjs/webcomponents-lite.js"></script>
   <link rel="import" href="../../polymer/polymer.html">
-  <script src="../../../browser.js"></script>
+  <script src="../../web-component-tester/browser.js"></script>
   <link rel="import" href="../dom-if-element.html">
   <link rel="import" href="../exception-fixture.html">
   <link rel="import" href="../projection-element.html">

--- a/test/fixtures/integration/nested/test/index.html
+++ b/test/fixtures/integration/nested/test/index.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites(['one/index.html', 'two/index.html', 'leaf.html', 'leaf.js']);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites(['one/index.html', 'two/index.html', 'leaf.html', 'leaf.js']);
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/nested/test/leaf.html
+++ b/test/fixtures/integration/nested/test/leaf.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      test('test', function() {});
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    test('test', function () { });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/nested/test/one/index.html
+++ b/test/fixtures/integration/nested/test/one/index.html
@@ -3,7 +3,7 @@
 
 <head>
   <meta charset="utf-8">
-  <script src="../../../../browser.js"></script>
+  <script src="/components/web-component-tester/browser.js"></script>
 </head>
 
 <body>

--- a/test/fixtures/integration/nested/test/one/tests.html
+++ b/test/fixtures/integration/nested/test/one/tests.html
@@ -3,12 +3,12 @@
 
 <head>
   <meta charset="utf-8">
-  <script src="../../../../browser.js"></script>
+  <script src="/components/web-component-tester/browser.js"></script>
 </head>
 
 <body>
   <script>
-    test('test', function() {});
+    test('test', function () { });
   </script>
 </body>
 

--- a/test/fixtures/integration/nested/test/two/index.html
+++ b/test/fixtures/integration/nested/test/two/index.html
@@ -3,12 +3,12 @@
 
 <head>
   <meta charset="utf-8">
-  <script src="../../../../browser.js"></script>
+  <script src="/components/web-component-tester/browser.js"></script>
 </head>
 
 <body>
   <script>
-    test('inline test', function() {});
+    test('inline test', function () { });
   </script>
 </body>
 

--- a/test/fixtures/integration/no-tests/test/index.html
+++ b/test/fixtures/integration/no-tests/test/index.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites([]);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites([]);
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/one-html/test/index.html
+++ b/test/fixtures/integration/one-html/test/index.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites(['tests.html']);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites(['tests.html']);
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/one-html/test/tests.html
+++ b/test/fixtures/integration/one-html/test/tests.html
@@ -1,15 +1,18 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      suite('suite', function() {
-        test('nested test', function() {});
-      });
-      test('test', function() {});
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    suite('suite', function () {
+      test('nested test', function () { });
+    });
+    test('test', function () { });
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/one-js/test/index.html
+++ b/test/fixtures/integration/one-js/test/index.html
@@ -1,12 +1,15 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites(['tests.js']);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites(['tests.js']);
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/query-string/test/index.html
+++ b/test/fixtures/integration/query-string/test/index.html
@@ -1,16 +1,19 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      WCT.loadSuites([
-        'tests.html?foo=bar',
-        'tests.js?fizz=buzz',
-        'tests.js?fizz=buzz&foo=bar',
-      ]);
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    WCT.loadSuites([
+      'tests.html?foo=bar',
+      'tests.js?fizz=buzz',
+      'tests.js?fizz=buzz&foo=bar',
+    ]);
+  </script>
+</body>
+
 </html>

--- a/test/fixtures/integration/query-string/test/tests.html
+++ b/test/fixtures/integration/query-string/test/tests.html
@@ -1,14 +1,17 @@
 <!doctype html>
 <html>
-  <head>
-    <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
-  </head>
-  <body>
-    <script>
-      test('preserves query strings', function() {
-        expect(window.location.search).to.eq('?foo=bar');
-      });
-    </script>
-  </body>
+
+<head>
+  <meta charset="utf-8">
+  <script src="/components/web-component-tester/browser.js"></script>
+</head>
+
+<body>
+  <script>
+    test('preserves query strings', function () {
+      expect(window.location.search).to.eq('?foo=bar');
+    });
+  </script>
+</body>
+
 </html>


### PR DESCRIPTION
 - Only tests were modified and only slightly.
  - specifically `<script src="../../../browser.js"></script>` became `<script src="/components/web-component-tester/browser.js"></script>`.
  - VS Code made some formatting adjustments to HTML and JSON indentation that were innocuous and consistent so I was fine not trying to undo those.
 - no CHANGELOG.md updates needed.
