### PR TITLE
Set test-fixture back to ^0.0.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-Added `sinon` as dependency of `sinon-chai` in web context to suppress the npm installation warning/error of unmet peer dependency, even though `@polymer/sinonjs` fulfills the runtime dependency and `sinon` will be unused.
-
+* Added `sinon` as dependency of `sinon-chai` in web context to suppress the npm installation warning/error of unmet peer dependency, even though `@polymer/sinonjs` fulfills the runtime dependency and `sinon` will be unused.
+* Set `@polymer/test-fixture` back to ^0.0.3 because of dependency install errors related to yarn's "flat".
 <!-- Add new, unreleased items here. -->
 
 ## 6.1.2 - 2017-08-22

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
   },
   "dependencies": {
     "@polymer/sinonjs": "^1.14.1",
-    "@polymer/test-fixture": "^3.0.0-pre.1",
+    "@polymer/test-fixture": "^0.0.3",
     "@webcomponents/webcomponentsjs": "^1.0.7",
     "accessibility-developer-tools": "^2.12.0",
     "async": "^1.5.2",


### PR DESCRIPTION
- [x] CHANGELOG.md has been updated
- Set `@polymer/test-fixture` back to ^0.0.3 because of dependency install errors related to yarn's "flat".
- Fixes https://github.com/Polymer/web-component-tester/issues/598
