### PR TITLE
Updated CHANGELOG for 6.1.3 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+<!-- Add new, unreleased items here. -->
+
+## 6.1.3 - 2017-08-26
+
 * Added `sinon` as dependency of `sinon-chai` in web context to suppress the npm installation warning/error of unmet peer dependency, even though `@polymer/sinonjs` fulfills the runtime dependency and `sinon` will be unused.
 * Set `@polymer/test-fixture` back to ^0.0.3 because of dependency install errors related to yarn's "flat".
-<!-- Add new, unreleased items here. -->
 
 ## 6.1.2 - 2017-08-22
 


### PR DESCRIPTION
This is a critical release because it resolves errors installing wct via yarn due to https://github.com/Polymer/web-component-tester/issues/598

## 6.1.3 - 2017-08-26

* Added `sinon` as dependency of `sinon-chai` in web context to suppress the npm installation warning/error of unmet peer dependency, even though `@polymer/sinonjs` fulfills the runtime dependency and `sinon` will be unused.
* Set `@polymer/test-fixture` back to ^0.0.3 because of dependency install errors related to yarn's "flat".
* [x] CHANGELOG.md has been updated
