### PR TITLE
Update CHANGELOG for 6.1.5 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-* Removed reliance on `document.currentScript` in browser.js because IE11 doesn't have it. (Second reference found)
 <!-- Add new, unreleased items here. -->
+
+## 6.1.5 - 2017-08-31
+
+* Removed reliance on `document.currentScript` in browser.js because IE11 doesn't have it. (Second reference found)
 
 ## 6.1.4 - 2017-08-31
 


### PR DESCRIPTION
 - Removed reliance on `document.currentScript` in browser.js because IE11 doesn't have it. (Second reference found)
 - [x] CHANGELOG.md has been updated
