### PR TITLE
re-run clang-format

### DIFF
--- a/runner/cli.ts
+++ b/runner/cli.ts
@@ -29,11 +29,11 @@ const noopNotifier = {
 let updateNotifier = noopNotifier;
 
 (function() {
-  try {
-    updateNotifier = require('update-notifier')({pkg: PACKAGE_INFO});
-  } catch (error) {
-    // S'ok if we don't have update-notifier. It's optional.
-  }
+try {
+  updateNotifier = require('update-notifier')({pkg: PACKAGE_INFO});
+} catch (error) {
+  // S'ok if we don't have update-notifier. It's optional.
+}
 })();
 
 export async function run(
@@ -72,10 +72,9 @@ async function _run(args: string[], output: NodeJS.WritableStream) {
 // wct-sauce. The trouble is that we also want WCT's configuration lookup logic,
 // and that's not (yet) cleanly exposed.
 export async function runSauceTunnel(
-    _env: any, args: string[], output: NodeJS.WritableStream):
-    Promise<void> {
-      await wrapResult(output, _runSauceTunnel(args, output));
-    }
+    _env: any, args: string[], output: NodeJS.WritableStream): Promise<void> {
+  await wrapResult(output, _runSauceTunnel(args, output));
+}
 
 async function _runSauceTunnel(args: string[], output: NodeJS.WritableStream) {
   const cmdOptions = config.preparseArgs(args) as config.Config;
@@ -113,8 +112,8 @@ async function _runSauceTunnel(args: string[], output: NodeJS.WritableStream) {
   output.write(chalk.cyan('export SAUCE_TUNNEL_ID=' + tunnelId) + '\n');
 }
 
-async function
-wrapResult(output: NodeJS.WritableStream, promise: Promise<void>) {
+async function wrapResult(
+    output: NodeJS.WritableStream, promise: Promise<void>) {
   let error: any;
   try {
     await promise;

--- a/runner/clireporter.ts
+++ b/runner/clireporter.ts
@@ -34,8 +34,8 @@ const STACKY_CONFIG = {
   ]
 };
 
-export type State = 'passing' | 'pending' | 'failing' | 'unknown' | 'error';
-export type CompletedState = 'passing' | 'failing' | 'pending' | 'unknown';
+export type State = 'passing'|'pending'|'failing'|'unknown'|'error';
+export type CompletedState = 'passing'|'failing'|'pending'|'unknown';
 type Formatter = (value: string) => string;
 
 const STATE_ICONS = {

--- a/runner/config.ts
+++ b/runner/config.ts
@@ -30,7 +30,7 @@ const HOME_DIR = path.resolve(
 const JSON_MATCHER = 'wct.conf.json';
 const CONFIG_MATCHER = 'wct.conf.*';
 
-export type Browser = string | {browserName: string, platform: string};
+export type Browser = string|{browserName: string, platform: string};
 
 export interface Config {
   suites?: string[];
@@ -164,7 +164,8 @@ export function defaults(): Config {
   };
 }
 
-/** nomnom configuration for command line arguments.
+/**
+ * nomnom configuration for command line arguments.
  *
  * This might feel like duplication with `defaults()`, and out of place (why not
  * in `cli.js`?). But, not every option matches a configurable value, and it is
@@ -473,9 +474,9 @@ function expandDeprecated(context: Context) {
         'The --browsers flag/option is deprecated. Please use ' +
             '--local and --sauce instead, or configure via plugins.' +
             '[local|sauce].browsers.');
-    const fragment: {plugins: {[name: string]: {browsers?: Browser[]}}} = {
-      plugins: {sauce: {}, local: {}}
-    };
+    const fragment: {
+      plugins: {[name: string]: {browsers?: Browser[]}}
+    } = {plugins: {sauce: {}, local: {}}};
     fragments.push(fragment);
 
     for (const browser of browsers) {

--- a/runner/context.ts
+++ b/runner/context.ts
@@ -24,10 +24,10 @@ import {Plugin} from './plugin';
 const JSON_MATCHER = 'wct.conf.json';
 const CONFIG_MATCHER = 'wct.conf.*';
 
-export type Handler = ((...args: any[]) => Promise<any>) |
-    ((done: (err?: any) => void) => void) |
-    ((arg1: any, done: (err?: any) => void) => void) |
-    ((arg1: any, arg2: any, done: (err?: any) => void) => void) |
+export type Handler =
+    ((...args: any[]) => Promise<any>)|((done: (err?: any) => void) => void)|
+    ((arg1: any, done: (err?: any) => void) => void)|
+    ((arg1: any, arg2: any, done: (err?: any) => void) => void)|
     ((arg1: any, arg2: any, arg3: any, done: (err?: any) => void) => void);
 
 /**
@@ -68,8 +68,7 @@ export class Context extends events.EventEmitter {
      * hold a reference to it, and make changes to it).
      */
     this.options = config.merge(
-        config.defaults(),
-        config.fromDisk(matcher, options.root), options);
+        config.defaults(), config.fromDisk(matcher, options.root), options);
   }
 
   // Hooks

--- a/runner/paths.ts
+++ b/runner/paths.ts
@@ -34,18 +34,16 @@ export async function expand(
 /**
  * Expands any glob expressions in `patterns`.
  */
-async function unglob(baseDir: string, patterns: string[]):
-    Promise<string[]> {
-      const strs: string[][] = [];
-      const pGlob: any = promisify(glob);
-      for (const pattern of patterns) {
-        strs.push(await pGlob(String(pattern), {cwd: baseDir, root: baseDir}));
-      }
+async function unglob(baseDir: string, patterns: string[]): Promise<string[]> {
+  const strs: string[][] = [];
+  const pGlob: any = promisify(glob);
+  for (const pattern of patterns) {
+    strs.push(await pGlob(String(pattern), {cwd: baseDir, root: baseDir}));
+  }
 
-      // for non-POSIX support, replacing path separators
-      return _.union(_.flatten(strs))
-          .map((str) => str.replace(/\//g, path.sep));
-    }
+  // for non-POSIX support, replacing path separators
+  return _.union(_.flatten(strs)).map((str) => str.replace(/\//g, path.sep));
+}
 
 /**
  * Expands any directories in `patterns`, following logic similar to a web

--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -107,8 +107,7 @@ export function webserver(wct: Context): void {
       if (!version) {
         throw new Error(`
 The web-component-tester Bower package is not installed as a dependency of this project (${
-                                                                                           packageName
-                                                                                         }).
+            packageName}).
 
 Please run this command to install:
     bower install --save-dev web-component-tester

--- a/test/integration/browser.ts
+++ b/test/integration/browser.ts
@@ -301,9 +301,8 @@ function assertTestErrors(
         .to.have.members(
             Object.keys(actual),
             'Test file mismatch for ' + browser +
-                `: expected ${
-                              JSON.stringify(Object.keys(expected))
-                            } - got ${JSON.stringify(Object.keys(actual))}`);
+                `: expected ${JSON.stringify(Object.keys(expected))} - got ${
+                    JSON.stringify(Object.keys(actual))}`);
 
     lodash.each(actual, function(errors, file) {
       const expectedErrors = expected[file];

--- a/test/unit/context.ts
+++ b/test/unit/context.ts
@@ -34,7 +34,7 @@ describe('Context', () => {
 
   describe('.plugins', () => {
 
-    it('excludes plugins with a falsy config', async() => {
+    it('excludes plugins with a falsy config', async () => {
       const context = new Context(<any>{plugins: {local: false, sauce: {}}});
       const stub = sandbox.stub(Plugin, 'get', (name: string) => {
         return Promise.resolve(name);
@@ -46,7 +46,7 @@ describe('Context', () => {
       expect(plugins).to.have.members(['sauce']);
     });
 
-    it('excludes plugins disabled: true', async() => {
+    it('excludes plugins disabled: true', async () => {
       const context =
           new Context(<any>{plugins: {local: {}, sauce: {disabled: true}}});
       const stub = sandbox.stub(Plugin, 'get', (name: string) => {
@@ -59,9 +59,9 @@ describe('Context', () => {
       expect(plugins).to.have.members(['local']);
     });
 
-    describe('hook handlers with non-callback second argument', async() => {
+    describe('hook handlers with non-callback second argument', async () => {
       it('are passed the "done" callback function instead of the argument passed to emitHook',
-         async() => {
+         async () => {
            const context = new Context();
            context.hook('foo', function(arg1: any, done: () => void) {
              expect(arg1).to.eq('hookArg');
@@ -72,7 +72,7 @@ describe('Context', () => {
     });
 
     describe('hook handlers written to call callbacks', () => {
-      it('passes additional arguments through', async() => {
+      it('passes additional arguments through', async () => {
         const context = new Context();
         context.hook(
             'foo',
@@ -92,7 +92,7 @@ describe('Context', () => {
         expect(error).to.not.be.ok;
       });
 
-      it('halts on error', async() => {
+      it('halts on error', async () => {
         const context = new Context();
         context.hook('bar', function(hookDone: (err?: any) => void) {
           hookDone('nope');
@@ -115,7 +115,7 @@ describe('Context', () => {
     });
 
     describe('hooks handlers written to return promises', () => {
-      it('passes additional arguments through', async() => {
+      it('passes additional arguments through', async () => {
         const context = new Context();
         context.hook('foo', async function(arg1: any, arg2: any) {
           expect(arg1).to.eq('one');
@@ -129,9 +129,9 @@ describe('Context', () => {
         expect(error).to.not.be.ok;
       });
 
-      it('halts on error', async() => {
+      it('halts on error', async () => {
         const context = new Context();
-        context.hook('bar', async() => {
+        context.hook('bar', async () => {
           throw 'nope';
         });
 

--- a/test/unit/paths.ts
+++ b/test/unit/paths.ts
@@ -29,32 +29,32 @@ describe('paths', function() {
       expect(actual).to.have.members(expected);
     }
 
-    it('is ok with an empty list', async() => {
+    it('is ok with an empty list', async () => {
       await expectExpands([], []);
     });
 
-    it('ignores explicit files that are missing', async() => {
+    it('ignores explicit files that are missing', async () => {
       await expectExpands(['404.js'], []);
       await expectExpands(['404.js', 'foo.html'], ['foo.html']);
     });
 
-    it('does not expand explicit files', async() => {
+    it('does not expand explicit files', async () => {
       await expectExpands(['foo.js'], ['foo.js']);
       await expectExpands(['foo.html'], ['foo.html']);
       await expectExpands(['foo.js', 'foo.html'], ['foo.js', 'foo.html']);
     });
 
-    it('expands directories into their files', async() => {
+    it('expands directories into their files', async () => {
       await expectExpands(['foo'], ['foo/one.js', 'foo/two.html']);
       await expectExpands(['foo/'], ['foo/one.js', 'foo/two.html']);
     });
 
-    it('expands directories into index.html when present', async() => {
+    it('expands directories into index.html when present', async () => {
       await expectExpands(['bar'], ['bar/index.html']);
       await expectExpands(['bar/'], ['bar/index.html']);
     });
 
-    it('expands directories recursively, honoring all rules', async() => {
+    it('expands directories recursively, honoring all rules', async () => {
       await expectExpands(['baz'], [
         'baz/a/fizz.html',
         'baz/b/index.html',
@@ -63,7 +63,7 @@ describe('paths', function() {
       ]);
     });
 
-    it('accepts globs for explicit file matches', async() => {
+    it('accepts globs for explicit file matches', async () => {
       await expectExpands(['baz/*.js'], ['baz/b.js']);
       await expectExpands(['baz/*.html'], ['baz/a.html']);
       await expectExpands(['baz/**/*.js'], [
@@ -81,7 +81,7 @@ describe('paths', function() {
     });
 
     it('accepts globs for directories, honoring directory behavior',
-       async() => {
+       async () => {
          await expectExpands(['*'], [
            'bar/index.html',
            'baz/a/fizz.html',
@@ -101,7 +101,7 @@ describe('paths', function() {
          ]);
        });
 
-    it('deduplicates', async() => {
+    it('deduplicates', async () => {
       await expectExpands(['bar/a.js', 'bar/*.js', 'bar', 'bar/*.html'], [
         'bar/a.js',
         'bar/index.html',


### PR DESCRIPTION
I did a clean install of dependencies, and then ran clang-format. It looks like some formatting rules may have changed /shrug.