### PR TITLE
Retry Failed Integration Tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7153,11 +7153,6 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -7176,6 +7171,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",


### PR DESCRIPTION
- WCT integration tests take a while to run (~12minutes on Travis) and often have a single failure that makes the whole run useless.  Needed to add some retry.
- Due to the way Mocha does retries, the current suite structure didn't really allow for it, so this is an attempt to get it to work.
- [ ] CHANGELOG.md has been updated

