### PR TITLE
Make integration tests try to re-run the browser connections to get fresh test results if something fails to support Mocha retries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Updated the browser.js file for npm case to use test-fixture as JS module instead of html import.
 * Updated the integration tests to support running on Sauce via wct-sauce plugin.
+* Updated teh integration tests to support retrying in case of failures.  This is important because Selenium and Sauce and reasons.
 <!-- Add new, unreleased items here. -->
 
 ## 6.1.5 - 2017-08-31

--- a/test/integration/browser.ts
+++ b/test/integration/browser.ts
@@ -144,10 +144,13 @@ function runsIntegrationSuite(
   describer(suiteName, function() {
     const log: string[] = [];
     const testResults = new TestResults();
+    let context: Context;
+    let freshTestResults = false;
+
+    this.retries(3);
+    this.timeout(60 * 10000);
 
     before(async function() {
-      this.timeout(300 * 1000);
-
       const suiteRoot = await makeProperTestDir(dirName);
       const allOptions: config.Config = Object.assign(
           {
@@ -160,7 +163,7 @@ function runsIntegrationSuite(
             },
           },
           options);
-      const context = new Context(allOptions);
+      context = new Context(allOptions);
 
       const addEventHandler = (name: string, handler: Function) => {
         context.on(name, function() {
@@ -210,10 +213,17 @@ function runsIntegrationSuite(
       addEventHandler('run-end', (error: any) => {
         testResults.runError = error;
       });
+    });
+
+    beforeEach(async () => {
+      if (freshTestResults) {
+        return;
+      }
 
       // Don't fail the integration suite on test errors.
       try {
         await test(context);
+        freshTestResults = true;
       } catch (error) {
         testResults.testRunnerError = error.message;
       }
@@ -221,6 +231,7 @@ function runsIntegrationSuite(
 
     afterEach(function() {
       if (this.currentTest.state === 'failed') {
+        freshTestResults = false;
         process.stderr.write(
             `\n    Output of wct for integration suite named \`${dirName}\`` +
             `\n` +
@@ -301,8 +312,9 @@ function assertTestErrors(
         .to.have.members(
             Object.keys(actual),
             'Test file mismatch for ' + browser +
-                `: expected ${JSON.stringify(Object.keys(expected))} - got ${
-                    JSON.stringify(Object.keys(actual))}`);
+                `: expected ${
+                              JSON.stringify(Object.keys(expected))
+                            } - got ${JSON.stringify(Object.keys(actual))}`);
 
     lodash.each(actual, function(errors, file) {
       const expectedErrors = expected[file];

--- a/test/integration/browser.ts
+++ b/test/integration/browser.ts
@@ -148,7 +148,7 @@ function runsIntegrationSuite(
     let freshTestResults = false;
 
     this.retries(3);
-    this.timeout(60 * 10000);
+    this.timeout(60 * 1000);
 
     before(async function() {
       const suiteRoot = await makeProperTestDir(dirName);

--- a/test/integration/browser.ts
+++ b/test/integration/browser.ts
@@ -148,7 +148,7 @@ function runsIntegrationSuite(
     let freshTestResults = false;
 
     this.retries(3);
-    this.timeout(60 * 1000);
+    this.timeout(300 * 1000);
 
     before(async function() {
       const suiteRoot = await makeProperTestDir(dirName);


### PR DESCRIPTION
- WCT integration tests take a while to run (~12minutes on Travis) and often have a single failure that makes the whole run useless. Needed to add some retry.
- Due to the way Mocha does retries, the current suite structure didn't really allow for it, so this is an attempt to get it to work.
- [ ] CHANGELOG.md has been updated