### PR TITLE
Prepare release 6.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Updated the browser.js file for npm case to use test-fixture as JS module instead of html import.
 * Updated the integration tests to support running on Sauce via wct-sauce plugin.
-* Updated polyserve to 0.22.0 for better compilation support and ES modules in HTML script tags.
+* Updated polyserve to 0.22.1 for better compilation support and ES modules in HTML script tags and bug fixes.
 * Updated bower.json to reference newly published test-fixture version 3.0.0.
 * No longer require `?npm=true` url parameter, as `web-component-tester` and `wct-browser-legacy` versions of `browser.js` now contain explicit npm/non-npm directives of the form `window.__wctUseNpm` as a first step towards splitting out the client-side environment-specific config and behavior.
 * Added support for scoped package names under npm.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 * Updated the browser.js file for npm case to use test-fixture as JS module instead of html import.
 * Updated the integration tests to support running on Sauce via wct-sauce plugin.
+* Updated polyserve to 0.22.0 for better compilation support and ES modules in HTML script tags.
+* Updated bower.json to reference newly published test-fixture version 3.0.0.
 * No longer require `?npm=true` url parameter, as `web-component-tester` and `wct-browser-legacy` versions of `browser.js` now contain explicit npm/non-npm directives of the form `window.__wctUseNpm` as a first step towards splitting out the client-side environment-specific config and behavior.
 * Added support for scoped package names under npm.
-* Updated polyserve to 0.22.0 for better compilation support and ES modules in HTML script tags.
 
 ## 6.1.5 - 2017-08-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,15 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
+<!-- Add new, unreleased items here. -->
+
+## 6.2.0 - 2017-09-19
 
 * Updated the browser.js file for npm case to use test-fixture as JS module instead of html import.
 * Updated the integration tests to support running on Sauce via wct-sauce plugin.
 * No longer require `?npm=true` url parameter, as `web-component-tester` and `wct-browser-legacy` versions of `browser.js` now contain explicit npm/non-npm directives of the form `window.__wctUseNpm` as a first step towards splitting out the client-side environment-specific config and behavior.
-<!-- Add new, unreleased items here. -->
+* Added support for scoped package names under npm.
+* Updated polyserve to 0.22.0 for better compilation support and ES modules in HTML script tags.
 
 ## 6.1.5 - 2017-08-31
 

--- a/bower.json
+++ b/bower.json
@@ -34,7 +34,7 @@
     "sinon-chai": "^2.7.0",
     "sinonjs": "^1.14.1",
     "stacky": "^1.3.0",
-    "test-fixture": "polymerelements/test-fixture#^3.0.0-rc.1"
+    "test-fixture": "^3.0.0"
   },
   "devDependencies": {
     "polymer": "Polymer/polymer#^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5837,9 +5837,9 @@
       }
     },
     "polyserve": {
-      "version": "0.22.0",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.22.0.tgz",
-      "integrity": "sha512-a2X+h17reUkrwhwTNW6LslS8ObpVpbqsMrJXVnK2CISMxRBjKpvI+Mshv3v9n6QQxOMVR2z0D3M3+QXuSz8FIw==",
+      "version": "0.22.1",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.22.1.tgz",
+      "integrity": "sha512-P7skbXsIIt97l9ndIdCvVgmaVdXq2cuWUa5ivp3I8ZNDq2KGpWUKxzTl9vFe+gdVyfyKmgV1df59CNiNf2RlSQ==",
       "requires": {
         "@types/assert": "0.0.29",
         "@types/babel-core": "6.25.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,22 @@
       "integrity": "sha1-jlYnhbqlq9p8BKSfZmXq50MZKNM="
     },
     "@types/babel-core": {
-      "version": "6.25.1",
-      "resolved": "https://registry.npmjs.org/@types/babel-core/-/babel-core-6.25.1.tgz",
-      "integrity": "sha512-u8V2quGRgIgoQ9BgmdNq7A4WJ7uChV7A3EHC5bnvQilsJIxAqlW1Y61t05JQhCCL3T176lQuffsyL+4GbnJh3w==",
+      "version": "6.25.2",
+      "resolved": "https://registry.npmjs.org/@types/babel-core/-/babel-core-6.25.2.tgz",
+      "integrity": "sha512-+Ush/fQHUDIithA5yDJWZiL6KdOiVOs5yuj4qcgvQOCnmJec+RgzkLgxnpgmM6Ear9RXa3aCcwjPiUnStPp1zA==",
       "requires": {
+        "@types/babel-generator": "6.25.0",
         "@types/babel-template": "6.25.0",
         "@types/babel-traverse": "6.25.2",
+        "@types/babel-types": "6.25.1",
+        "@types/babylon": "6.16.2"
+      }
+    },
+    "@types/babel-generator": {
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/@types/babel-generator/-/babel-generator-6.25.0.tgz",
+      "integrity": "sha512-WbrKGSt8SKOxAivCHB1fsIP59EyCCfMHuCYcA6yenjGxnjh0rK3BOSPHR96RdZD6ukgyDwzMF/biQH4llowTDg==",
+      "requires": {
         "@types/babel-types": "6.25.1"
       }
     },
@@ -60,9 +70,9 @@
       }
     },
     "@types/bluebird": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.8.tgz",
-      "integrity": "sha512-rBfrD56OxaqVjghtVqp2EEX0ieHkRk6IefDVrQXIVGvlhDOEBTvZff4Q02uo84ukVkH4k5eB1cPKGDM2NlFL8A=="
+      "version": "3.5.11",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.11.tgz",
+      "integrity": "sha512-tL3ySMpaih/6mJqP8NLfIhQ+qxXvU1Lb+AP+fQ46ZA6/gAQm09GfDiS+C32UgP05kbA2tA4M3B6+oXfkRDpKMQ=="
     },
     "@types/body-parser": {
       "version": "0.0.33",
@@ -142,16 +152,16 @@
       "resolved": "https://registry.npmjs.org/@types/express/-/express-4.0.37.tgz",
       "integrity": "sha512-tIULTLzQpFFs5/PKnFIAFOsXQxss76glppbVKR3/jddPK26SBsD5HF5grn5G2jOGtpRWSBvYmDYoduVv+3wOXg==",
       "requires": {
-        "@types/express-serve-static-core": "4.0.50",
+        "@types/express-serve-static-core": "4.0.53",
         "@types/serve-static": "1.7.32"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.0.50",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.50.tgz",
-      "integrity": "sha512-0n1YgeUfZEIaMMu82LuOFIFDyMtFtcEP0yjQKihJlNjpCiygDVri7C26DC7jaUOwFXL6ZU2x4tGtNYNEgeO3tw==",
+      "version": "4.0.53",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.53.tgz",
+      "integrity": "sha512-zaGeOpEYp5G2EhjaUFdVwysDrfEYc6Q6iPhd3Kl4ip30x0tvVv7SuJvY3yzCUSuFlzAG8N5KsyY6BJg93/cn+Q==",
       "requires": {
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@types/freeport": {
@@ -166,7 +176,7 @@
       "integrity": "sha512-DMcj5b67Alb/e4KhpzyvphC5nVDHn1oCOGZao3oBddZVMH5vgI/cvdp+O/kcxZGZaPqs0ZLAsK4YrjbtZHO05g==",
       "requires": {
         "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       },
       "dependencies": {
         "@types/minimatch": {
@@ -182,7 +192,7 @@
       "integrity": "sha512-UxdJkuoXh48URR4gJSAQAXSTeo98KTsEalJc+7wNmWrkK+8/z/V71tddUYzxtM/nlDJEKHW5Fbyh02KuHwlytg==",
       "requires": {
         "@types/glob": "5.0.32",
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@types/grunt": {
@@ -191,7 +201,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@types/gulp": {
@@ -200,7 +210,7 @@
       "integrity": "sha512-3UpA2pkKO40cNPe/8bxMQFWSASR9Jx67JfN9Z2Cf6ogfDMwXgEHm2XjKmuLYEtrp1IHYApOWlYMLYNgtTJgSAw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.25",
+        "@types/node": "8.0.28",
         "@types/orchestrator": "0.3.0",
         "@types/vinyl": "2.0.1"
       }
@@ -229,9 +239,9 @@
       "dev": true
     },
     "@types/mocha": {
-      "version": "2.2.42",
-      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.42.tgz",
-      "integrity": "sha512-b6gVDoxEbAQGwbV7gSzeFw/hy3/eEAokztktdzl4bHvGgb9K5zW4mVQDlVYch2w31m8t/J7L2iqhQvz3r5edCQ==",
+      "version": "2.2.43",
+      "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-2.2.43.tgz",
+      "integrity": "sha512-xNlAmH+lRJdUMXClMTI9Y0pRqIojdxfm7DHsIxoB2iTzu3fnPmSMEN8SsSx0cdwV36d02PWCWaDUoZPDSln+xw==",
       "dev": true
     },
     "@types/multer": {
@@ -248,14 +258,14 @@
       "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
       "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
       "requires": {
-        "@types/bluebird": "3.5.8",
-        "@types/node": "8.0.25"
+        "@types/bluebird": "3.5.11",
+        "@types/node": "8.0.28"
       }
     },
     "@types/node": {
-      "version": "8.0.25",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.25.tgz",
-      "integrity": "sha512-zT+t9841g1HsjLtPMCYxmb1U4pcZ2TOegAKiomlmj6bIziuaEYHUavxLE9NRwdntY0vOCrgHho6OXjDX7fm/Kw=="
+      "version": "8.0.28",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
+      "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ=="
     },
     "@types/nomnom": {
       "version": "0.0.28",
@@ -268,7 +278,7 @@
       "resolved": "https://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "requires": {
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@types/orchestrator": {
@@ -277,8 +287,8 @@
       "integrity": "sha1-v4ShaZyTMNT+ic2BJj6PwJ+zKXg=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.25",
-        "@types/q": "0.0.36"
+        "@types/node": "8.0.28",
+        "@types/q": "0.0.37"
       }
     },
     "@types/parse5": {
@@ -286,7 +296,7 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "requires": {
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@types/pem": {
@@ -295,9 +305,9 @@
       "integrity": "sha1-zQsZXRYd/7ywqoj6n9lLJN0q8Qs="
     },
     "@types/q": {
-      "version": "0.0.36",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.36.tgz",
-      "integrity": "sha512-5OG6OQdxmoLTJNXLglYmGGbspeD+uPnrzlatdO5WE2DImKF6oDZ6kv4PyOFlICMg1xl5eWKR3W5o/oL6b1bjWg==",
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-0.0.37.tgz",
+      "integrity": "sha512-vjFGX1zMTMz/kUp3xgfJcxMVLkMWVMrdlyc0RwVyve1y9jxwqNaT8wTcv6M51ylq2a/zn5lm8g7qPSoIS4uvZQ==",
       "dev": true
     },
     "@types/rimraf": {
@@ -317,7 +327,7 @@
       "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.7.32.tgz",
       "integrity": "sha512-WpI0g7M1FiOmJ/a97Qrjafq2I938tjAZ3hZr9O7sXyA6oUhH3bqUNZIt7r1KZg8TQAKxcvxt6JjQ5XuLfIBFvg==",
       "requires": {
-        "@types/express-serve-static-core": "4.0.50",
+        "@types/express-serve-static-core": "4.0.53",
         "@types/mime": "0.0.29"
       }
     },
@@ -343,7 +353,7 @@
       "integrity": "sha512-YkaCkyqbbxNa1Hpix1YAVhPG9X/PDat75l96Hbrf3uDoQ9u/9aDjgG2N+KqW8DpV8U70VmVEyA2/ilbTA/np6w==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@types/spdy": {
@@ -351,7 +361,7 @@
       "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.2.tgz",
       "integrity": "sha512-MfIOcqTpECcKEMEAtpRQJqAdczKk/R55VGRfi5PDUlbpndrPz5t+knh7E3X0MnBMEOpRFY1oubLy81RHa6HrPg==",
       "requires": {
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@types/ua-parser-js": {
@@ -364,7 +374,7 @@
       "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.1.tgz",
       "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
       "requires": {
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@types/vinyl-fs": {
@@ -373,7 +383,7 @@
       "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
       "requires": {
         "@types/glob-stream": "3.1.31",
-        "@types/node": "8.0.25",
+        "@types/node": "8.0.28",
         "@types/vinyl": "2.0.1"
       }
     },
@@ -384,17 +394,17 @@
       "optional": true
     },
     "@types/winston": {
-      "version": "2.3.5",
-      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.5.tgz",
-      "integrity": "sha512-qMkxq+pSJgqE9I5NKEDJvZgLe+jK9ItOOQL9Ee2miUTPZMBKVWSx55suLaiwrGyQ/VqHhuD9Jv31wko1eTaKqQ==",
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.6.tgz",
+      "integrity": "sha512-gZsUc53u4JHqt5nvfgTnjNP1SkzDmDtY7eZz/8WUFL43Pp8KMR+g8LiHjslwLLheIS/hfGH55QW4tJVjNwYh/Q==",
       "requires": {
-        "@types/node": "8.0.25"
+        "@types/node": "8.0.28"
       }
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.8.tgz",
-      "integrity": "sha512-OMueiM5AJWTPTAD2KhFIB1wUFXAagXB6VPIyvpluy+5XoZ8Xod+vea6Q80F5PRwUIe/q1rpWFmnxKDNINs0nsw=="
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.11.tgz",
+      "integrity": "sha512-9PeWMJLU2FKGtz6/nr9WU5pdyT2JOgQil6ggTd3bjjgHCDHvijaI1effstqe6VtOmiL8eO6lOL2jb435LaUK1g=="
     },
     "abbrev": {
       "version": "1.1.0",
@@ -407,7 +417,7 @@
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
       "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
       "requires": {
-        "mime-types": "2.1.16",
+        "mime-types": "2.1.17",
         "negotiator": "0.6.1"
       }
     },
@@ -417,9 +427,9 @@
       "integrity": "sha1-PaDM6dbsY3OWS4TzXbfPw996tRQ="
     },
     "acorn": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.1.tgz",
-      "integrity": "sha512-vOk6uEMctu0vQrvuSqFdJyqj1Q0S5VTDL79qtjo+DhRr+1mmaD+tluFSCZqhvi/JUhXSzoZN2BhtstaPEeE8cw=="
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.1.2.tgz",
+      "integrity": "sha512-o96FZLJBPY1lvTuJylGA9Bk3t/GKPPJG8H0ydQQl01crzwJgspa4AEIq/pVTXigmK0PHVQhiAtn8WMBLL9D2WA=="
     },
     "acorn-jsx": {
       "version": "3.0.1",
@@ -468,7 +478,8 @@
     "amdefine": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
-      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+      "dev": true
     },
     "ansi-align": {
       "version": "1.1.0",
@@ -771,14 +782,6 @@
         "source-map": "0.5.7"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -1026,6 +1029,27 @@
         "babel-runtime": "6.26.0"
       }
     },
+    "babel-plugin-transform-es2015-modules-amd": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
+      "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
+      "requires": {
+        "babel-plugin-transform-es2015-modules-commonjs": "6.26.0",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0"
+      }
+    },
+    "babel-plugin-transform-es2015-modules-commonjs": {
+      "version": "6.26.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.0.tgz",
+      "integrity": "sha1-DYOUApt9xqvhqX7xgeAHWN0uXYo=",
+      "requires": {
+        "babel-plugin-transform-strict-mode": "6.24.1",
+        "babel-runtime": "6.26.0",
+        "babel-template": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
@@ -1109,6 +1133,15 @@
         "regenerator-transform": "0.10.1"
       }
     },
+    "babel-plugin-transform-strict-mode": {
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
+      "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
+      "requires": {
+        "babel-runtime": "6.26.0",
+        "babel-types": "6.26.0"
+      }
+    },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
@@ -1116,11 +1149,11 @@
       "requires": {
         "babel-core": "6.26.0",
         "babel-runtime": "6.26.0",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "home-or-tmp": "2.0.0",
         "lodash": "4.17.4",
         "mkdirp": "0.5.1",
-        "source-map-support": "0.4.16"
+        "source-map-support": "0.4.18"
       },
       "dependencies": {
         "lodash": {
@@ -1135,7 +1168,7 @@
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "requires": {
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "regenerator-runtime": "0.11.0"
       }
     },
@@ -1174,14 +1207,6 @@
         "lodash": "4.17.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "lodash": {
           "version": "4.17.4",
           "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
@@ -1299,19 +1324,19 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "body-parser": {
-      "version": "1.17.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.17.2.tgz",
-      "integrity": "sha1-+IkqvI+eYn1Crtr7yma/WrmRBO4=",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.1.tgz",
+      "integrity": "sha512-KL2pZpGvy6xuZHgYUznB1Zfw4AoGMApfRanT5NafeLvglbaSM+4CCtmlyYOv66oYXqvKL1xpaFb94V/AZVUnYg==",
       "requires": {
-        "bytes": "2.4.0",
-        "content-type": "1.0.2",
-        "debug": "2.6.7",
+        "bytes": "3.0.0",
+        "content-type": "1.0.4",
+        "debug": "2.6.8",
         "depd": "1.1.1",
         "http-errors": "1.6.2",
-        "iconv-lite": "0.4.15",
+        "iconv-lite": "0.4.19",
         "on-finished": "2.3.0",
-        "qs": "6.4.0",
-        "raw-body": "2.2.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
         "type-is": "1.6.15"
       }
     },
@@ -1324,9 +1349,9 @@
       }
     },
     "bower": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.0.tgz",
-      "integrity": "sha1-Vdvr7wrZFVOC2enT5JfBNyNFtEo=",
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/bower/-/bower-1.8.2.tgz",
+      "integrity": "sha1-rfU1KcjUrwLvJPuNU0HBQZ0z4vc=",
       "dev": true
     },
     "boxen": {
@@ -1371,6 +1396,15 @@
         "repeat-element": "1.1.2"
       }
     },
+    "browser-capabilities": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/browser-capabilities/-/browser-capabilities-0.2.0.tgz",
+      "integrity": "sha512-DGqul/36J8Pn+Ko4hrNjozeplctd/Dhb8V2gh3jxyqoYgisqCqlBSDmEb/xLRX47GXhav/NNITnpEcpW41ohzQ==",
+      "requires": {
+        "@types/ua-parser-js": "0.7.32",
+        "ua-parser-js": "0.7.14"
+      }
+    },
     "browser-stdout": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.0.tgz",
@@ -1405,9 +1439,9 @@
       }
     },
     "bytes": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "callsite": {
       "version": "1.0.0",
@@ -1460,10 +1494,15 @@
         "supports-color": "2.0.0"
       }
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+    },
     "clang-format": {
-      "version": "1.0.53",
-      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.53.tgz",
-      "integrity": "sha1-/zZoxA7M7u6qPpd7YdUBBtCz/UY=",
+      "version": "1.0.55",
+      "resolved": "https://registry.npmjs.org/clang-format/-/clang-format-1.0.55.tgz",
+      "integrity": "sha1-gDEnEynieneaXQj8Xc4k18UsFNU=",
       "dev": true,
       "requires": {
         "async": "1.5.2",
@@ -1637,7 +1676,7 @@
       "resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.11.tgz",
       "integrity": "sha1-FnGKdd4oPtjmBAQWJaIGRYZ5fYo=",
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "1.30.0"
       }
     },
     "compression": {
@@ -1658,14 +1697,6 @@
           "version": "2.5.0",
           "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
           "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
-        },
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
         }
       }
     },
@@ -1746,9 +1777,9 @@
       "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.2.tgz",
-      "integrity": "sha1-t9ETrueo3Se9IRM8TcJSnfFyHu0="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA=="
     },
     "convert-source-map": {
       "version": "1.5.0",
@@ -1766,9 +1797,9 @@
       "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-js": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.0.tgz",
-      "integrity": "sha1-VpwFCRi+ZIazg3VSAorgRmtxcIY="
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
+      "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1826,6 +1857,11 @@
         "capture-stack-trace": "1.0.0"
       }
     },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+    },
     "cryptiles": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
@@ -1880,9 +1916,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.7.tgz",
-      "integrity": "sha1-krrR9tBbu2u6Isyoi80OyJTChh4=",
+      "version": "2.6.8",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
       "requires": {
         "ms": "2.0.0"
       }
@@ -1950,7 +1986,7 @@
         "builtin-modules": "1.1.1",
         "deprecate": "1.0.0",
         "deps-regex": "0.1.4",
-        "js-yaml": "3.9.1",
+        "js-yaml": "3.10.0",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
         "require-package-name": "2.0.1",
@@ -2240,7 +2276,7 @@
           "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.3.tgz",
           "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
           "requires": {
-            "mime-types": "2.1.16",
+            "mime-types": "2.1.17",
             "negotiator": "0.6.1"
           }
         },
@@ -2350,46 +2386,30 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.1.tgz",
-      "integrity": "sha1-WltTr0aTEQvrsIZ6o0MN07cKEBg=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.0.tgz",
+      "integrity": "sha512-v0MYvNQ32bzwoG2OSFzWAkuahDQHK92JBN0pTAALJ4RIxEZe766QJPDR8Hqy7XNUy5K3fnVL76OqYAdc4TZEIw==",
       "requires": {
-        "esprima": "2.7.3",
-        "estraverse": "1.9.3",
+        "esprima": "3.1.3",
+        "estraverse": "4.2.0",
         "esutils": "2.0.2",
         "optionator": "0.8.2",
-        "source-map": "0.2.0"
-      },
-      "dependencies": {
-        "estraverse": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz",
-          "integrity": "sha1-r2fy3JIlgkFZUJJgkaQAXSnJu0Q="
-        },
-        "source-map": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz",
-          "integrity": "sha1-2rc/vPwrqBm03gO9b26qSBZLP50=",
-          "optional": true,
-          "requires": {
-            "amdefine": "1.0.1"
-          }
-        }
+        "source-map": "0.5.7"
       }
     },
     "espree": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.0.tgz",
-      "integrity": "sha1-mDWGJb3QVYYeon4oZ+pyn69GPY0=",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.1.tgz",
+      "integrity": "sha1-DJiLirRttTEAoZVK5LqZXd0n2H4=",
       "requires": {
-        "acorn": "5.1.1",
+        "acorn": "5.1.2",
         "acorn-jsx": "3.0.1"
       }
     },
     "esprima": {
-      "version": "2.7.3",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.3.tgz",
-      "integrity": "sha1-luO3DVd59q1JzQMmc9HDEnZ7pYE="
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "estraverse": {
       "version": "4.2.0",
@@ -2402,9 +2422,9 @@
       "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.0.tgz",
-      "integrity": "sha1-b2Ma7zNtbEY2K1F2QETOIWvjwFE="
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "eventemitter2": {
       "version": "0.4.14",
@@ -2418,9 +2438,9 @@
       "integrity": "sha1-HIaZHYFq0eUEdQ5zh0Ik7PO+xQg="
     },
     "exec-sh": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.0.tgz",
-      "integrity": "sha1-FPdd4/INKG75MwmbLOUKkDWc7xA=",
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/exec-sh/-/exec-sh-0.2.1.tgz",
+      "integrity": "sha512-aLt95pexaugVtQerpmE51+4QfWrNc304uez7jvj6fWnN8GeEHpttB8F36n8N7uVhUMbH/1enbxQ9HImZ4w/9qg==",
       "dev": true,
       "requires": {
         "merge": "1.2.0"
@@ -2470,20 +2490,20 @@
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
         "content-disposition": "0.5.2",
-        "content-type": "1.0.2",
+        "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
         "debug": "2.6.8",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "etag": "1.8.0",
-        "finalhandler": "1.0.4",
+        "etag": "1.8.1",
+        "finalhandler": "1.0.5",
         "fresh": "0.5.0",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
         "proxy-addr": "1.1.5",
         "qs": "6.5.0",
@@ -2497,14 +2517,6 @@
         "vary": "1.1.1"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "qs": {
           "version": "6.5.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
@@ -2520,7 +2532,7 @@
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
-            "etag": "1.8.0",
+            "etag": "1.8.1",
             "fresh": "0.5.0",
             "http-errors": "1.6.2",
             "mime": "1.3.4",
@@ -2636,27 +2648,17 @@
       "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
     },
     "finalhandler": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.4.tgz",
-      "integrity": "sha512-16l/r8RgzlXKmFOhZpHBztvye+lAhC5SU7hXavnerC9UfZqZxxXl3BzL8MhffPT3kF61lj9Oav2LKEzh0ei7tg==",
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz",
+      "integrity": "sha1-pwEwPSV6G8gv6lR6M+WuiVMXI98=",
       "requires": {
         "debug": "2.6.8",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "statuses": "1.3.1",
         "unpipe": "1.0.0"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "find-index": {
@@ -2775,7 +2777,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.16"
+        "mime-types": "2.1.17"
       }
     },
     "formatio": {
@@ -2787,9 +2789,9 @@
       }
     },
     "forwarded": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.0.tgz",
-      "integrity": "sha1-Ge+YdMSuHCl7zweP3mOgm2aoQ2M="
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "freeport": {
       "version": "1.0.5",
@@ -3454,7 +3456,7 @@
         "chalk": "1.1.3",
         "deprecated": "0.0.1",
         "gulp-util": "3.0.8",
-        "interpret": "1.0.3",
+        "interpret": "1.0.4",
         "liftoff": "2.3.0",
         "minimist": "1.2.0",
         "orchestrator": "0.3.8",
@@ -3611,7 +3613,7 @@
       "integrity": "sha1-fKTjxaWZ0I+torHAVMzozeTnQjU=",
       "dev": true,
       "requires": {
-        "bower": "1.8.0",
+        "bower": "1.8.2",
         "gulp-util": "3.0.8",
         "inquirer": "0.11.4",
         "through2": "0.6.2",
@@ -3908,6 +3910,11 @@
         "sntp": "1.0.9"
       }
     },
+    "he": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.1.1.tgz",
+      "integrity": "sha1-k0EP0hsAlzUVH4howvJx80J+I/0="
+    },
     "hoek": {
       "version": "2.16.3",
       "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
@@ -4062,14 +4069,14 @@
       "optional": true,
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.7",
+        "debug": "2.6.8",
         "extend": "3.0.1"
       }
     },
     "iconv-lite": {
-      "version": "0.4.15",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-      "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
+      "version": "0.4.19",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ=="
     },
     "imurmurhash": {
       "version": "0.1.4",
@@ -4130,9 +4137,9 @@
       }
     },
     "interpret": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
-      "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.4.tgz",
+      "integrity": "sha1-ggzdWIuGj/sZGoCVBtbJyPISsbA=",
       "dev": true
     },
     "invariant": {
@@ -4374,9 +4381,9 @@
       "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
-      "version": "3.9.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.9.1.tgz",
-      "integrity": "sha512-CbcG379L1e+mWBnLvHWWeLs8GyV/EMw862uLI3c+GxVyDHWZcjZinwuBd3iW2pgxgIlksW/1vNJa4to+RvDOww==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+      "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
       "dev": true,
       "requires": {
         "argparse": "1.0.9",
@@ -4531,7 +4538,7 @@
       "requires": {
         "async": "2.5.0",
         "browserstack": "1.5.0",
-        "debug": "2.6.7",
+        "debug": "2.6.8",
         "plist": "2.1.0",
         "q": "1.5.0",
         "underscore": "1.8.3"
@@ -4898,6 +4905,16 @@
       "integrity": "sha1-5WqpTEyAVaFkBKBnS3jyFffI4ZQ=",
       "dev": true
     },
+    "md5": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+      "integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "1.1.5"
+      }
+    },
     "media-typer": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
@@ -4997,7 +5014,7 @@
         "normalize-path": "2.1.1",
         "object.omit": "2.0.1",
         "parse-glob": "3.0.4",
-        "regex-cache": "0.4.3"
+        "regex-cache": "0.4.4"
       }
     },
     "mime": {
@@ -5006,16 +5023,16 @@
       "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
     },
     "mime-db": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
-      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg="
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+      "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
     },
     "mime-types": {
-      "version": "2.1.16",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
-      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+      "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
       "requires": {
-        "mime-db": "1.29.0"
+        "mime-db": "1.30.0"
       }
     },
     "minimalistic-assert": {
@@ -5053,9 +5070,9 @@
       }
     },
     "mocha": {
-      "version": "3.5.0",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.0.tgz",
-      "integrity": "sha512-pIU2PJjrPYvYRqVpjXzj76qltO9uBYI7woYAMoxbSefsa+vqAfptjoeevd6bUgwD0mPIO+hv9f7ltvsNreL2PA==",
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-3.5.3.tgz",
+      "integrity": "sha512-/6na001MJWEtYxHOV1WLfsmR4YIynkUEhBwzsb+fk2qmQ3iqsi258l/Q2MWHJMImAcNpZ8DEdYAK72NHoIQ9Eg==",
       "requires": {
         "browser-stdout": "1.3.0",
         "commander": "2.9.0",
@@ -5064,20 +5081,13 @@
         "escape-string-regexp": "1.0.5",
         "glob": "7.1.1",
         "growl": "1.9.2",
+        "he": "1.1.1",
         "json3": "3.3.2",
         "lodash.create": "3.1.1",
         "mkdirp": "0.5.1",
         "supports-color": "3.1.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
@@ -5144,9 +5154,9 @@
       "dev": true
     },
     "mz": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mz/-/mz-2.6.0.tgz",
-      "integrity": "sha1-yLhSHZWN8KTydoAl22nHGe5O8c4=",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/mz/-/mz-2.7.0.tgz",
+      "integrity": "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==",
       "requires": {
         "any-promise": "1.3.0",
         "object-assign": "4.1.1",
@@ -5590,9 +5600,9 @@
       }
     },
     "parseurl": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.1.tgz",
-      "integrity": "sha1-yKuMkiO6NIiKpkopeyiFO+wY2lY="
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "path-dirname": {
       "version": "1.0.2",
@@ -5648,11 +5658,13 @@
       }
     },
     "pem": {
-      "version": "1.9.7",
-      "resolved": "https://registry.npmjs.org/pem/-/pem-1.9.7.tgz",
-      "integrity": "sha1-04f5lvKSx8nepjmlNYBedMtQMWE=",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.11.0.tgz",
+      "integrity": "sha512-GLBcz6QzdugRJYqMNL76bYCJmQlPHA7czPnWq5sLHyjkh91OeNv+AbUmHirZNZVcEm3PLMdK6Av5UyO/qP/02A==",
       "requires": {
+        "md5": "2.2.1",
         "os-tmpdir": "1.0.2",
+        "safe-buffer": "5.1.1",
         "which": "1.3.0"
       }
     },
@@ -5706,7 +5718,7 @@
       "integrity": "sha1-yXbrodgNLdmRAF18EQ2vh0FUeI8=",
       "requires": {
         "@types/node": "4.2.20",
-        "@types/winston": "2.3.5",
+        "@types/winston": "2.3.6",
         "winston": "2.3.1"
       },
       "dependencies": {
@@ -5736,8 +5748,8 @@
         "cssbeautify": "0.3.1",
         "doctrine": "2.0.0",
         "dom5": "2.3.0",
-        "escodegen": "1.8.1",
-        "espree": "3.5.0",
+        "escodegen": "1.9.0",
+        "espree": "3.5.1",
         "estraverse": "4.2.0",
         "jsonschema": "1.2.0",
         "parse5": "2.2.3",
@@ -5764,7 +5776,7 @@
         "@types/vinyl-fs": "0.0.28",
         "dom5": "2.3.0",
         "multipipe": "1.0.2",
-        "mz": "2.6.0",
+        "mz": "2.7.0",
         "parse5": "2.2.3",
         "plylog": "0.5.0",
         "polymer-analyzer": "2.2.2",
@@ -5799,7 +5811,7 @@
         "command-line-args": "3.0.5",
         "command-line-usage": "3.0.8",
         "dom5": "2.3.0",
-        "espree": "3.5.0",
+        "espree": "3.5.1",
         "mkdirp": "0.5.1",
         "parse5": "2.2.3",
         "polymer-analyzer": "2.2.2",
@@ -5825,18 +5837,19 @@
       }
     },
     "polyserve": {
-      "version": "0.20.0",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.20.0.tgz",
-      "integrity": "sha512-i99n2lHz2Xuje7dRZAFx4DhLPLhZyDiiBz6QLaq0TmWEjqoDYsf/EFikemD2SEz8Cf4Q03Tn0E6EZ742KuXGhw==",
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.22.0.tgz",
+      "integrity": "sha512-a2X+h17reUkrwhwTNW6LslS8ObpVpbqsMrJXVnK2CISMxRBjKpvI+Mshv3v9n6QQxOMVR2z0D3M3+QXuSz8FIw==",
       "requires": {
         "@types/assert": "0.0.29",
-        "@types/babel-core": "6.25.1",
+        "@types/babel-core": "6.25.2",
+        "@types/babylon": "6.16.2",
         "@types/compression": "0.0.33",
         "@types/content-type": "1.1.1",
         "@types/express": "4.0.37",
         "@types/mime": "0.0.29",
         "@types/mz": "0.0.29",
-        "@types/node": "8.0.25",
+        "@types/node": "8.0.28",
         "@types/opn": "3.0.28",
         "@types/parse5": "2.2.34",
         "@types/pem": "1.9.2",
@@ -5854,6 +5867,7 @@
         "babel-plugin-transform-es2015-for-of": "6.23.0",
         "babel-plugin-transform-es2015-function-name": "6.24.1",
         "babel-plugin-transform-es2015-literals": "6.22.0",
+        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
         "babel-plugin-transform-es2015-object-super": "6.24.1",
         "babel-plugin-transform-es2015-parameters": "6.24.1",
         "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
@@ -5863,25 +5877,27 @@
         "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
         "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
         "babel-plugin-transform-regenerator": "6.26.0",
+        "babylon": "6.18.0",
+        "browser-capabilities": "0.2.0",
         "command-line-args": "3.0.5",
         "command-line-usage": "3.0.8",
         "compression": "1.7.0",
-        "content-type": "1.0.2",
+        "content-type": "1.0.4",
         "dom5": "2.3.0",
         "express": "4.15.4",
         "find-port": "1.0.1",
         "http-proxy-middleware": "0.17.4",
         "lru-cache": "4.1.1",
         "mime": "1.3.4",
-        "mz": "2.6.0",
+        "mz": "2.7.0",
         "opn": "3.0.3",
         "parse5": "2.2.3",
-        "pem": "1.9.7",
+        "pem": "1.11.0",
         "polymer-build": "2.0.0",
+        "requirejs": "2.3.5",
         "resolve": "1.4.0",
         "send": "0.14.2",
-        "spdy": "3.4.7",
-        "ua-parser-js": "0.7.14"
+        "spdy": "3.4.7"
       },
       "dependencies": {
         "debug": {
@@ -6014,7 +6030,7 @@
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
       "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
       "requires": {
-        "forwarded": "0.1.0",
+        "forwarded": "0.1.2",
         "ipaddr.js": "1.4.0"
       }
     },
@@ -6035,9 +6051,9 @@
       "optional": true
     },
     "qs": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
-      "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A=="
     },
     "randomatic": {
       "version": "1.1.7",
@@ -6082,12 +6098,13 @@
       "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
       "requires": {
-        "bytes": "2.4.0",
-        "iconv-lite": "0.4.15",
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
         "unpipe": "1.0.0"
       }
     },
@@ -6245,9 +6262,9 @@
       "integrity": "sha1-JYx479FT3fk8tWEjf2EYTzaW4yc="
     },
     "regenerate": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.2.tgz",
-      "integrity": "sha1-0ZQcZ7rUN+G+dkM63Vs4X5WxkmA="
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
+      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg=="
     },
     "regenerator-runtime": {
       "version": "0.11.0",
@@ -6265,12 +6282,11 @@
       }
     },
     "regex-cache": {
-      "version": "0.4.3",
-      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.3.tgz",
-      "integrity": "sha1-mxpsNdTQ3871cRrmUejp09cRQUU=",
+      "version": "0.4.4",
+      "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "requires": {
-        "is-equal-shallow": "0.1.3",
-        "is-primitive": "2.0.0"
+        "is-equal-shallow": "0.1.3"
       }
     },
     "regexpu-core": {
@@ -6278,7 +6294,7 @@
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
       "requires": {
-        "regenerate": "1.3.2",
+        "regenerate": "1.3.3",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -6366,7 +6382,7 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.16",
+        "mime-types": "2.1.17",
         "oauth-sign": "0.8.2",
         "qs": "6.3.2",
         "stringstream": "0.0.5",
@@ -6405,6 +6421,11 @@
       "integrity": "sha1-wR6XJ2tluOKSP3Xav1+y7ww4Qbk=",
       "dev": true
     },
+    "requirejs": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.5.tgz",
+      "integrity": "sha512-svnO+aNcR/an9Dpi44C7KSAy5fFGLtmPbaaCeQaklUz8BQhS64tWWIIlvEA5jrWICzlO/X9KSzSeXFnZdBu8nw=="
+    },
     "requires-port": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
@@ -6438,9 +6459,9 @@
       }
     },
     "rimraf": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
-      "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
       "requires": {
         "glob": "7.1.2"
       }
@@ -6527,7 +6548,7 @@
         "async": "2.5.0",
         "https-proxy-agent": "1.0.0",
         "lodash": "4.17.4",
-        "rimraf": "2.6.1"
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "async": {
@@ -6737,18 +6758,10 @@
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
-        "parseurl": "1.3.1",
+        "parseurl": "1.3.2",
         "send": "0.15.4"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "send": {
           "version": "0.15.4",
           "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
@@ -6759,7 +6772,7 @@
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
-            "etag": "1.8.0",
+            "etag": "1.8.1",
             "fresh": "0.5.0",
             "http-errors": "1.6.2",
             "mime": "1.3.4",
@@ -6981,9 +6994,9 @@
       "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
     },
     "source-map-support": {
-      "version": "0.4.16",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.16.tgz",
-      "integrity": "sha512-A6vlydY7H/ljr4L2UOhDSajQdZQ6dMD7cLH0pzwcmwLyc9u8PNI4WGtnfDDzX7uzGL6c/T+ORL97Zlh+S4iOrg==",
+      "version": "0.4.18",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "requires": {
         "source-map": "0.5.7"
       }
@@ -7023,16 +7036,6 @@
         "safe-buffer": "5.1.1",
         "select-hose": "2.0.0",
         "spdy-transport": "2.0.20"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        }
       }
     },
     "spdy-transport": {
@@ -7049,14 +7052,6 @@
         "wbuf": "1.7.2"
       },
       "dependencies": {
-        "debug": {
-          "version": "2.6.8",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
-          "requires": {
-            "ms": "2.0.0"
-          }
-        },
         "readable-stream": {
           "version": "2.3.3",
           "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.3.tgz",
@@ -7269,7 +7264,7 @@
       "integrity": "sha1-buINxIPbNxs+XIf3BO0vfHmdLJo=",
       "requires": {
         "array-back": "1.0.4",
-        "core-js": "2.5.0",
+        "core-js": "2.5.1",
         "deep-extend": "0.4.2",
         "feature-detect-es6": "1.3.1",
         "typical": "2.6.1",
@@ -7547,7 +7542,7 @@
       "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.16"
+        "mime-types": "2.1.17"
       }
     },
     "typedarray": {
@@ -7556,9 +7551,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.4.2.tgz",
-      "integrity": "sha1-+DlfhdRZJ2BnyYiqQYN6j4KHCEQ=",
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
+      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
       "dev": true
     },
     "typical": {
@@ -7819,7 +7814,7 @@
       "integrity": "sha1-KAlUdsbffJDJYxOJkMClQj60uYY=",
       "dev": true,
       "requires": {
-        "exec-sh": "0.2.0",
+        "exec-sh": "0.2.1",
         "minimist": "1.2.0"
       },
       "dependencies": {
@@ -7884,9 +7879,9 @@
       }
     },
     "wd": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/wd/-/wd-1.4.0.tgz",
-      "integrity": "sha512-VHii2f+jck5fgEcTQYCR3z99B99tPz0HlLCGsNowI2qsI21xMnKwd9O3SnJQnEBq0Erx9FPFfiZno+OYtXDXyw==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/wd/-/wd-1.4.1.tgz",
+      "integrity": "sha512-C0wWd2X4SWWcyx5qxaixiZE4Vb07sl0yDfWHPeml8lDHSbmI9erE9BmTHIqOGoDxGgJ3/hkFmODQ7ZLKiF8+8Q==",
       "requires": {
         "archiver": "1.3.0",
         "async": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mocha": "^3.4.2",
     "multer": "^1.3.0",
     "nomnom": "^1.8.1",
-    "polyserve": "^0.20.0",
+    "polyserve": "^0.22.0",
     "promisify-node": "^0.4.0",
     "resolve": "^1.3.3",
     "semver": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mocha": "^3.4.2",
     "multer": "^1.3.0",
     "nomnom": "^1.8.1",
-    "polyserve": "^0.22.0",
+    "polyserve": "^0.22.1",
     "promisify-node": "^0.4.0",
     "resolve": "^1.3.3",
     "semver": "^5.3.0",

--- a/wct-browser-legacy/package.json
+++ b/wct-browser-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-browser-legacy",
-  "version": "0.0.1-pre.7",
+  "version": "0.0.1-pre.8",
   "description": "Client-side dependencies for web-component-tester tests installed via npm.",
   "main": "browser.js",
   "license": "http://polymer.github.io/LICENSE.txt",


### PR DESCRIPTION
* Updated the browser.js file for npm case to use test-fixture as JS module instead of html import.
* Updated the integration tests to support running on Sauce via wct-sauce plugin.
* Updated polyserve to 0.22.0 for better compilation support and ES modules in HTML script tags.
* Updated bower.json to use test-fixture 3.0.0!
* No longer require `?npm=true` url parameter, as `web-component-tester` and `wct-browser-legacy` versions of `browser.js` now contain explicit npm/non-npm directives of the form `window.__wctUseNpm` as a first step towards splitting out the client-side environment-specific config and behavior.
* Added support for scoped package names under npm.
* [x] CHANGELOG.md has been updated
