### PR TITLE
Fixed #547: --webserver-port option doesn't change the actual port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased items here. -->
+* Fixed #547: WCT now respects webserver.port configuration option
 
 ## 6.2.0 - 2017-09-19
 

--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -171,6 +171,7 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
       root: options.root,
       compile: options.compile,
       hostname: options.webserver.hostname,
+      port: options.webserver.port,
       headers: DEFAULT_HEADERS,
       packageName,
       additionalRoutes,


### PR DESCRIPTION
**WCT** now respects _webserver.port_ configuration option

[ x ] CHANGELOG.md has been updated