### PR TITLE
Prepare Release 6.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased items here. -->
+
+## 6.3.0 - 2017-10-02
+
 * Updated wct-browser-legacy to use a module version of a11ySuite to get access to Polymer.dom.flush.
 * Updated generated index for webserver to use a11ySuite as a module.
+* Updated polyserve to get support for on-the-fly module compilation and `<script type=module>` conversion for browsers that don't support modules.
 
 ## 6.2.0 - 2017-09-19
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -70,9 +70,9 @@
       }
     },
     "@types/bluebird": {
-      "version": "3.5.11",
-      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.11.tgz",
-      "integrity": "sha512-tL3ySMpaih/6mJqP8NLfIhQ+qxXvU1Lb+AP+fQ46ZA6/gAQm09GfDiS+C32UgP05kbA2tA4M3B6+oXfkRDpKMQ=="
+      "version": "3.5.12",
+      "resolved": "https://registry.npmjs.org/@types/bluebird/-/bluebird-3.5.12.tgz",
+      "integrity": "sha512-ILfYPIxcSxXk0S2AGCDwtjrIB2bo2TMIJwvJ/MZG7iQgGuj4Wc92ipMiLXaMCE/lgFWhzljEDuoTQXNHYwJhuA=="
     },
     "@types/body-parser": {
       "version": "0.0.33",
@@ -142,10 +142,18 @@
       "resolved": "https://registry.npmjs.org/@types/escodegen/-/escodegen-0.0.2.tgz",
       "integrity": "sha1-fOpBqyQukQ6xD2WuGK66RZ1ms18="
     },
+    "@types/estraverse": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/@types/estraverse/-/estraverse-0.0.6.tgz",
+      "integrity": "sha1-Zp9833KreX5hJfjQD+0z1M8wwiE=",
+      "requires": {
+        "@types/estree": "0.0.37"
+      }
+    },
     "@types/estree": {
-      "version": "0.0.34",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.34.tgz",
-      "integrity": "sha1-qnr2mjqRkiFx7kEbPJ2Pa+tK8yE="
+      "version": "0.0.37",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.37.tgz",
+      "integrity": "sha512-1IT6vNpmU9w18P3v6mN9idv18z5KPVTi4t7+rU9VLnkxo0LCam8IXy/eSVzOaQ1Wpabra2cN3A8K/SliPK/Suw=="
     },
     "@types/express": {
       "version": "4.0.37",
@@ -161,7 +169,7 @@
       "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.0.53.tgz",
       "integrity": "sha512-zaGeOpEYp5G2EhjaUFdVwysDrfEYc6Q6iPhd3Kl4ip30x0tvVv7SuJvY3yzCUSuFlzAG8N5KsyY6BJg93/cn+Q==",
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@types/freeport": {
@@ -176,7 +184,7 @@
       "integrity": "sha512-DMcj5b67Alb/e4KhpzyvphC5nVDHn1oCOGZao3oBddZVMH5vgI/cvdp+O/kcxZGZaPqs0ZLAsK4YrjbtZHO05g==",
       "requires": {
         "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       },
       "dependencies": {
         "@types/minimatch": {
@@ -192,7 +200,7 @@
       "integrity": "sha512-UxdJkuoXh48URR4gJSAQAXSTeo98KTsEalJc+7wNmWrkK+8/z/V71tddUYzxtM/nlDJEKHW5Fbyh02KuHwlytg==",
       "requires": {
         "@types/glob": "5.0.32",
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@types/grunt": {
@@ -201,7 +209,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@types/gulp": {
@@ -210,7 +218,7 @@
       "integrity": "sha512-3UpA2pkKO40cNPe/8bxMQFWSASR9Jx67JfN9Z2Cf6ogfDMwXgEHm2XjKmuLYEtrp1IHYApOWlYMLYNgtTJgSAw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28",
+        "@types/node": "8.0.31",
         "@types/orchestrator": "0.3.0",
         "@types/vinyl": "2.0.1"
       }
@@ -222,9 +230,9 @@
       "optional": true
     },
     "@types/lodash": {
-      "version": "4.14.74",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.74.tgz",
-      "integrity": "sha512-BZknw3E/z3JmCLqQVANcR17okqVTPZdlxvcIz0fJiJVLUCbSH1hK3zs9r634PVSmrzAxN+n/fxlVRiYoArdOIQ==",
+      "version": "4.14.76",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.76.tgz",
+      "integrity": "sha512-D9fps/hN+XLF7G6SprwfxSxT3SFpKF3qix5IUx41AxwI9Zrdv+3Gqn1gprb3/O/+x6lpT9STJEZib6sogddPpA==",
       "dev": true
     },
     "@types/mime": {
@@ -258,14 +266,14 @@
       "resolved": "https://registry.npmjs.org/@types/mz/-/mz-0.0.29.tgz",
       "integrity": "sha1-vCRyjGSZc/HHhR6QM/nOUlZowns=",
       "requires": {
-        "@types/bluebird": "3.5.11",
-        "@types/node": "8.0.28"
+        "@types/bluebird": "3.5.12",
+        "@types/node": "8.0.31"
       }
     },
     "@types/node": {
-      "version": "8.0.28",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.28.tgz",
-      "integrity": "sha512-HupkFXEv3O3KSzcr3Ylfajg0kaerBg1DyaZzRBBQfrU3NN1mTBRE7sCveqHwXLS5Yrjvww8qFzkzYQQakG9FuQ=="
+      "version": "8.0.31",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.31.tgz",
+      "integrity": "sha512-R+LdMJHJQwRd/Ca0Nr5KnwbSWHxTD3DWz4ivqoPeNH+YPcuirMWK+Ti9Mx32jOecmPhHOCd+6CefU5e1eVq2Ew=="
     },
     "@types/nomnom": {
       "version": "0.0.28",
@@ -278,7 +286,7 @@
       "resolved": "https://registry.npmjs.org/@types/opn/-/opn-3.0.28.tgz",
       "integrity": "sha1-CX0NHJtXSVc6XZbfEyOHu20CEYo=",
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@types/orchestrator": {
@@ -287,7 +295,7 @@
       "integrity": "sha1-v4ShaZyTMNT+ic2BJj6PwJ+zKXg=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28",
+        "@types/node": "8.0.31",
         "@types/q": "0.0.37"
       }
     },
@@ -296,7 +304,7 @@
       "resolved": "https://registry.npmjs.org/@types/parse5/-/parse5-2.2.34.tgz",
       "integrity": "sha1-44cKEOgnNacg9i1x3NGDunjvOp0=",
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@types/pem": {
@@ -353,15 +361,15 @@
       "integrity": "sha512-YkaCkyqbbxNa1Hpix1YAVhPG9X/PDat75l96Hbrf3uDoQ9u/9aDjgG2N+KqW8DpV8U70VmVEyA2/ilbTA/np6w==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@types/spdy": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.2.tgz",
-      "integrity": "sha512-MfIOcqTpECcKEMEAtpRQJqAdczKk/R55VGRfi5PDUlbpndrPz5t+knh7E3X0MnBMEOpRFY1oubLy81RHa6HrPg==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/@types/spdy/-/spdy-3.4.3.tgz",
+      "integrity": "sha512-PqoT6ns3fRCnT45KBxOr7cNS7B24WsX7pnVdco2TbTzpvd/nYstMt3BmuyS7u90+Cs3H+whVc221fRNGFxfIgQ==",
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@types/ua-parser-js": {
@@ -374,7 +382,7 @@
       "resolved": "https://registry.npmjs.org/@types/vinyl/-/vinyl-2.0.1.tgz",
       "integrity": "sha512-Joudabfn2ZofU2usW04y8OLmN75u7ZQkW0MCT3AnoBf5oUBp5iQ3Pgfz9+y1RdWkzhCPZo9/wBJ7FMWW2JrY0g==",
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@types/vinyl-fs": {
@@ -383,7 +391,7 @@
       "integrity": "sha1-RmMBe8gCxlcOrk80Cf1cq/l8v94=",
       "requires": {
         "@types/glob-stream": "3.1.31",
-        "@types/node": "8.0.28",
+        "@types/node": "8.0.31",
         "@types/vinyl": "2.0.1"
       }
     },
@@ -398,18 +406,18 @@
       "resolved": "https://registry.npmjs.org/@types/winston/-/winston-2.3.6.tgz",
       "integrity": "sha512-gZsUc53u4JHqt5nvfgTnjNP1SkzDmDtY7eZz/8WUFL43Pp8KMR+g8LiHjslwLLheIS/hfGH55QW4tJVjNwYh/Q==",
       "requires": {
-        "@types/node": "8.0.28"
+        "@types/node": "8.0.31"
       }
     },
     "@webcomponents/webcomponentsjs": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.11.tgz",
-      "integrity": "sha512-9PeWMJLU2FKGtz6/nr9WU5pdyT2JOgQil6ggTd3bjjgHCDHvijaI1effstqe6VtOmiL8eO6lOL2jb435LaUK1g=="
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/@webcomponents/webcomponentsjs/-/webcomponentsjs-1.0.14.tgz",
+      "integrity": "sha512-YtxQ9S318BmLLkc8I4hmugg+P1HXgLrPoTCwNJkEH4nt+qxEkp7lv7xi/ljEnSxprxAYQrQt4kHJajs8G7069A=="
     },
     "abbrev": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.0.tgz",
-      "integrity": "sha1-0FVMIlZjbi9W58LlrRg/hZQo2B8=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "accepts": {
@@ -772,7 +780,7 @@
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
         "convert-source-map": "1.5.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "json5": "0.5.1",
         "lodash": "4.17.4",
         "minimatch": "3.0.4",
@@ -1201,7 +1209,7 @@
         "babel-runtime": "6.26.0",
         "babel-types": "6.26.0",
         "babylon": "6.18.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "globals": "9.18.0",
         "invariant": "2.2.2",
         "lodash": "4.17.4"
@@ -1324,13 +1332,13 @@
       "integrity": "sha1-vPEwUspURj8w+fx+lbmkdjCpSSE="
     },
     "body-parser": {
-      "version": "1.18.1",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.1.tgz",
-      "integrity": "sha512-KL2pZpGvy6xuZHgYUznB1Zfw4AoGMApfRanT5NafeLvglbaSM+4CCtmlyYOv66oYXqvKL1xpaFb94V/AZVUnYg==",
+      "version": "1.18.2",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
       "requires": {
         "bytes": "3.0.0",
         "content-type": "1.0.4",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "http-errors": "1.6.2",
         "iconv-lite": "0.4.19",
@@ -1697,24 +1705,17 @@
       }
     },
     "compression": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.0.tgz",
-      "integrity": "sha1-AwyfGY8WQ6BX13anOOki2kNzAS0=",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/compression/-/compression-1.7.1.tgz",
+      "integrity": "sha1-7/JgPvwuIs+G810uuTWJ+YdTc9s=",
       "requires": {
         "accepts": "1.3.4",
-        "bytes": "2.5.0",
+        "bytes": "3.0.0",
         "compressible": "2.0.11",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "on-headers": "1.0.1",
         "safe-buffer": "5.1.1",
-        "vary": "1.1.1"
-      },
-      "dependencies": {
-        "bytes": {
-          "version": "2.5.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.5.0.tgz",
-          "integrity": "sha1-TJQj6i0lLCcMQbK97+/5u2tiwGo="
-        }
+        "vary": "1.1.2"
       }
     },
     "concat-map": {
@@ -1842,14 +1843,14 @@
       "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
       "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
       "requires": {
-        "crc": "3.4.4",
+        "crc": "3.5.0",
         "readable-stream": "2.3.3"
       },
       "dependencies": {
         "crc": {
-          "version": "3.4.4",
-          "resolved": "https://registry.npmjs.org/crc/-/crc-3.4.4.tgz",
-          "integrity": "sha1-naHpgOO9RPxck79as9ozeNheRms="
+          "version": "3.5.0",
+          "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+          "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
         },
         "readable-stream": {
           "version": "2.3.3",
@@ -1942,9 +1943,9 @@
       "dev": true
     },
     "debug": {
-      "version": "2.6.8",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
-      "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "requires": {
         "ms": "2.0.0"
       }
@@ -2129,7 +2130,7 @@
       "resolved": "https://registry.npmjs.org/dom-urls/-/dom-urls-1.1.0.tgz",
       "integrity": "sha1-AB3fgWKM0ecGElxxdvU8zsVdkY4=",
       "requires": {
-        "urijs": "1.18.12"
+        "urijs": "1.19.0"
       }
     },
     "dom5": {
@@ -2509,64 +2510,66 @@
       }
     },
     "express": {
-      "version": "4.15.4",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.15.4.tgz",
-      "integrity": "sha1-Ay4iU0ic+PzgJma+yj0R7XotrtE=",
+      "version": "4.16.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.16.1.tgz",
+      "integrity": "sha512-STB7LZ4N0L+81FJHGla2oboUHTk4PaN1RsOkoRh9OSeEKylvF5hwKYVX1xCLFaCT7MD0BNG/gX2WFMLqY6EMBw==",
       "requires": {
         "accepts": "1.3.4",
         "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
         "content-disposition": "0.5.2",
         "content-type": "1.0.4",
         "cookie": "0.3.1",
         "cookie-signature": "1.0.6",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "depd": "1.1.1",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
-        "finalhandler": "1.0.5",
-        "fresh": "0.5.0",
+        "finalhandler": "1.1.0",
+        "fresh": "0.5.2",
         "merge-descriptors": "1.0.1",
         "methods": "1.1.2",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
         "path-to-regexp": "0.1.7",
-        "proxy-addr": "1.1.5",
-        "qs": "6.5.0",
+        "proxy-addr": "2.0.2",
+        "qs": "6.5.1",
         "range-parser": "1.2.0",
-        "send": "0.15.4",
-        "serve-static": "1.12.4",
-        "setprototypeof": "1.0.3",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.1",
+        "serve-static": "1.13.1",
+        "setprototypeof": "1.1.0",
         "statuses": "1.3.1",
         "type-is": "1.6.15",
-        "utils-merge": "1.0.0",
-        "vary": "1.1.1"
+        "utils-merge": "1.0.1",
+        "vary": "1.1.2"
       },
       "dependencies": {
-        "qs": {
-          "version": "6.5.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.0.tgz",
-          "integrity": "sha512-fjVFjW9yhqMhVGwRExCXLhJKrLlkYSaxNWdyc9rmHlrVZbk35YHH312dFd7191uQeXkI3mKLZTIbSvIeFwFemg=="
-        },
         "send": {
-          "version": "0.15.4",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-          "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
           "requires": {
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "depd": "1.1.1",
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
             "etag": "1.8.1",
-            "fresh": "0.5.0",
+            "fresh": "0.5.2",
             "http-errors": "1.6.2",
-            "mime": "1.3.4",
+            "mime": "1.4.1",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
             "range-parser": "1.2.0",
             "statuses": "1.3.1"
           }
+        },
+        "setprototypeof": {
+          "version": "1.1.0",
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
         }
       }
     },
@@ -2674,11 +2677,11 @@
       "integrity": "sha1-w8T2xmO5I0WamqKZEtLQMfFQf4Q="
     },
     "finalhandler": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.0.5.tgz",
-      "integrity": "sha1-pwEwPSV6G8gv6lR6M+WuiVMXI98=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+      "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
@@ -2826,9 +2829,9 @@
       "optional": true
     },
     "fresh": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.0.tgz",
-      "integrity": "sha1-9HTKXmqSRtb9jglTz6m5yAWvp44="
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-exists-sync": {
       "version": "0.1.0",
@@ -3800,7 +3803,7 @@
         "array-uniq": "1.0.3",
         "beeper": "1.1.1",
         "chalk": "1.1.3",
-        "dateformat": "2.0.0",
+        "dateformat": "2.2.0",
         "fancy-log": "1.3.0",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
@@ -3823,9 +3826,9 @@
           "dev": true
         },
         "dateformat": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.0.0.tgz",
-          "integrity": "sha1-J0Pjq7XD/CRi5SfcpEXgTp9N7hc=",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-2.2.0.tgz",
+          "integrity": "sha1-QGXiATz5+5Ft39gu+1Bq1MZ2kGI=",
           "dev": true
         },
         "duplexer2": {
@@ -4134,7 +4137,7 @@
       "optional": true,
       "requires": {
         "agent-base": "2.1.1",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "extend": "3.0.1"
       }
     },
@@ -4222,9 +4225,9 @@
       "dev": true
     },
     "ipaddr.js": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.4.0.tgz",
-      "integrity": "sha1-KWrKh4qCGBbluF0KKFqZvP9FgvA="
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+      "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
     },
     "irregular-plurals": {
       "version": "1.3.0",
@@ -4603,7 +4606,7 @@
       "requires": {
         "async": "2.5.0",
         "browserstack": "1.5.0",
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "plist": "2.1.0",
         "q": "1.5.0",
         "underscore": "1.8.3"
@@ -5083,9 +5086,9 @@
       }
     },
     "mime": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
-      "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ=="
     },
     "mime-db": {
       "version": "1.30.0",
@@ -5153,6 +5156,14 @@
         "supports-color": "3.1.2"
       },
       "dependencies": {
+        "debug": {
+          "version": "2.6.8",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.8.tgz",
+          "integrity": "sha1-5zFTHKLt4n0YgiJCfaF4IdaP9Pw=",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
         "glob": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
@@ -5296,7 +5307,7 @@
       "integrity": "sha1-bd0hvSoxQXuScn3Vhfim83YI6+4=",
       "dev": true,
       "requires": {
-        "abbrev": "1.1.0"
+        "abbrev": "1.1.1"
       }
     },
     "normalize-package-data": {
@@ -5723,9 +5734,9 @@
       }
     },
     "pem": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/pem/-/pem-1.11.0.tgz",
-      "integrity": "sha512-GLBcz6QzdugRJYqMNL76bYCJmQlPHA7czPnWq5sLHyjkh91OeNv+AbUmHirZNZVcEm3PLMdK6Av5UyO/qP/02A==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/pem/-/pem-1.12.0.tgz",
+      "integrity": "sha512-ojA2yoroH3VxyDWZ8fiG59B9N2VVclOTOB6CBBr8lmKQaReWUDAhucsiLN4LlBF3tdMdlnQ59qwopxm7RvmhPw==",
       "requires": {
         "md5": "2.2.1",
         "os-tmpdir": "1.0.2",
@@ -5784,7 +5795,7 @@
       "requires": {
         "@types/node": "4.2.20",
         "@types/winston": "2.3.6",
-        "winston": "2.3.1"
+        "winston": "2.4.0"
       },
       "dependencies": {
         "@types/node": {
@@ -5795,9 +5806,9 @@
       }
     },
     "polymer-analyzer": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.2.2.tgz",
-      "integrity": "sha512-8kwxAAx95AMJbDQ1x6vKyCkTDnowG5q1nn8gPf91PP+GNgQhgVRPBeLZQzpPyHY7dplvOyEoBhtjZvaQDg5teA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/polymer-analyzer/-/polymer-analyzer-2.3.0.tgz",
+      "integrity": "sha512-mgvLJ7hez52/Iy54GGFVRs9CoO0jXWeS2Iqows5GJpL+KnFiR1afziI2s/5teQcC53vtPUtWba8PEeQHroD5Hw==",
       "requires": {
         "@types/chai-subset": "1.3.1",
         "@types/chalk": "0.4.31",
@@ -5805,7 +5816,8 @@
         "@types/cssbeautify": "0.3.1",
         "@types/doctrine": "0.0.1",
         "@types/escodegen": "0.0.2",
-        "@types/estree": "0.0.34",
+        "@types/estraverse": "0.0.6",
+        "@types/estree": "0.0.37",
         "@types/node": "6.0.88",
         "@types/parse5": "2.2.34",
         "chalk": "1.1.3",
@@ -5818,7 +5830,7 @@
         "estraverse": "4.2.0",
         "jsonschema": "1.2.0",
         "parse5": "2.2.3",
-        "shady-css-parser": "0.0.8",
+        "shady-css-parser": "0.1.0",
         "strip-indent": "2.0.0"
       },
       "dependencies": {
@@ -5830,9 +5842,9 @@
       }
     },
     "polymer-build": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-2.0.0.tgz",
-      "integrity": "sha512-3m5BiEBZBYV3+tHk5OBgxypfQBkP3MuYpp8UbdQblf2uR1JopyWsLw55xbxdCpHqbjG0/KqSE9FcHx+ZGRKpkQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/polymer-build/-/polymer-build-2.1.0.tgz",
+      "integrity": "sha512-1I/bS4Jz6ed7WXDHES+mJ4v1hdexYZlMDvf2pmO1JvO2WwxUG4tlEdyhxn0T6jG7lES8y3NEfrB44/wilkpATQ==",
       "requires": {
         "@types/mz": "0.0.31",
         "@types/node": "6.0.88",
@@ -5844,8 +5856,8 @@
         "mz": "2.7.0",
         "parse5": "2.2.3",
         "plylog": "0.5.0",
-        "polymer-analyzer": "2.2.2",
-        "polymer-bundler": "3.0.1",
+        "polymer-analyzer": "2.3.0",
+        "polymer-bundler": "3.1.0",
         "polymer-project-config": "3.4.0",
         "sw-precache": "5.2.0",
         "vinyl": "1.2.0",
@@ -5868,9 +5880,9 @@
       }
     },
     "polymer-bundler": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-3.0.1.tgz",
-      "integrity": "sha512-nimtMd5n+PfrKqSlJCx4dXUJLoocZ79/rce7OvV6CraQjWP/waPcIYbIQfUm0NGz8LqCJlyu5SN+IIbv0HNLIw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/polymer-bundler/-/polymer-bundler-3.1.0.tgz",
+      "integrity": "sha512-iBeqzoapRTMernTeoaJSAzmsJtCRNV5CRpUoncZCs+P80x6SX0YMxANPcTEWha4GtIQmo+suNVE4DdMm5oTJ4Q==",
       "requires": {
         "clone": "2.1.1",
         "command-line-args": "3.0.5",
@@ -5879,7 +5891,7 @@
         "espree": "3.5.1",
         "mkdirp": "0.5.1",
         "parse5": "2.2.3",
-        "polymer-analyzer": "2.2.2",
+        "polymer-analyzer": "2.3.0",
         "source-map": "0.5.7"
       }
     },
@@ -5902,9 +5914,9 @@
       }
     },
     "polyserve": {
-      "version": "0.22.1",
-      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.22.1.tgz",
-      "integrity": "sha512-P7skbXsIIt97l9ndIdCvVgmaVdXq2cuWUa5ivp3I8ZNDq2KGpWUKxzTl9vFe+gdVyfyKmgV1df59CNiNf2RlSQ==",
+      "version": "0.23.0",
+      "resolved": "https://registry.npmjs.org/polyserve/-/polyserve-0.23.0.tgz",
+      "integrity": "sha512-ijzCbFttKG1F0hMTWWIzMoo+sxsfpXctoHFigw2ViBcvUt/aUBfJCUTHPKHhi/3zAgtw5Ej3SgoIOY9LflpXAw==",
       "requires": {
         "@types/assert": "0.0.29",
         "@types/babel-core": "6.25.2",
@@ -5914,12 +5926,12 @@
         "@types/express": "4.0.37",
         "@types/mime": "0.0.29",
         "@types/mz": "0.0.29",
-        "@types/node": "8.0.28",
+        "@types/node": "8.0.31",
         "@types/opn": "3.0.28",
         "@types/parse5": "2.2.34",
         "@types/pem": "1.9.2",
         "@types/serve-static": "1.7.32",
-        "@types/spdy": "3.4.2",
+        "@types/spdy": "3.4.3",
         "@types/ua-parser-js": "0.7.32",
         "babel-core": "6.26.0",
         "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
@@ -5946,19 +5958,19 @@
         "browser-capabilities": "0.2.0",
         "command-line-args": "3.0.5",
         "command-line-usage": "3.0.8",
-        "compression": "1.7.0",
+        "compression": "1.7.1",
         "content-type": "1.0.4",
         "dom5": "2.3.0",
-        "express": "4.15.4",
+        "express": "4.16.1",
         "find-port": "1.0.1",
         "http-proxy-middleware": "0.17.4",
         "lru-cache": "4.1.1",
-        "mime": "1.3.4",
+        "mime": "1.4.1",
         "mz": "2.7.0",
         "opn": "3.0.3",
         "parse5": "2.2.3",
-        "pem": "1.11.0",
-        "polymer-build": "2.0.0",
+        "pem": "1.12.0",
+        "polymer-build": "2.1.0",
         "requirejs": "2.3.5",
         "resolve": "1.4.0",
         "send": "0.14.2",
@@ -6023,6 +6035,13 @@
             "on-finished": "2.3.0",
             "range-parser": "1.2.0",
             "statuses": "1.3.1"
+          },
+          "dependencies": {
+            "mime": {
+              "version": "1.3.4",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.3.4.tgz",
+              "integrity": "sha1-EV+eO2s9rylZmDyzjxSaLUDrXVM="
+            }
           }
         },
         "setprototypeof": {
@@ -6091,12 +6110,12 @@
       }
     },
     "proxy-addr": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-1.1.5.tgz",
-      "integrity": "sha1-ccDuOxAt4/IC87ZPYI0XP8uhqRg=",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+      "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
       "requires": {
         "forwarded": "0.1.2",
-        "ipaddr.js": "1.4.0"
+        "ipaddr.js": "1.5.2"
       }
     },
     "pseudomap": {
@@ -6451,7 +6470,7 @@
         "oauth-sign": "0.8.2",
         "qs": "6.3.2",
         "stringstream": "0.0.5",
-        "tough-cookie": "2.3.2",
+        "tough-cookie": "2.3.3",
         "tunnel-agent": "0.4.3",
         "uuid": "3.1.0"
       },
@@ -6817,30 +6836,30 @@
       "dev": true
     },
     "serve-static": {
-      "version": "1.12.4",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.12.4.tgz",
-      "integrity": "sha1-m2qpjutyU8Tu3Ewfb9vKYJkBqWE=",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.1.tgz",
+      "integrity": "sha512-hSMUZrsPa/I09VYFJwa627JJkNs0NrfL1Uzuup+GqHfToR2KcsXFymXSV90hoyw3M+msjFuQly+YzIH/q0MGlQ==",
       "requires": {
         "encodeurl": "1.0.1",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
-        "send": "0.15.4"
+        "send": "0.16.1"
       },
       "dependencies": {
         "send": {
-          "version": "0.15.4",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.15.4.tgz",
-          "integrity": "sha1-mF+qPihLAnPHkzZKNcZze9k5Bbk=",
+          "version": "0.16.1",
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.1.tgz",
+          "integrity": "sha512-ElCLJdJIKPk6ux/Hocwhk7NFHpI3pVm/IZOYWqUmoxcgeyM+MpxHHKhb8QmlJDX1pU6WrgaHBkVNm73Sv7uc2A==",
           "requires": {
-            "debug": "2.6.8",
+            "debug": "2.6.9",
             "depd": "1.1.1",
             "destroy": "1.0.4",
             "encodeurl": "1.0.1",
             "escape-html": "1.0.3",
             "etag": "1.8.1",
-            "fresh": "0.5.0",
+            "fresh": "0.5.2",
             "http-errors": "1.6.2",
-            "mime": "1.3.4",
+            "mime": "1.4.1",
             "ms": "2.0.0",
             "on-finished": "2.3.0",
             "range-parser": "1.2.0",
@@ -6871,9 +6890,9 @@
       "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
     },
     "shady-css-parser": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.0.8.tgz",
-      "integrity": "sha1-Ae7FprnsjkftvakbRN/lkSeeoNE="
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/shady-css-parser/-/shady-css-parser-0.1.0.tgz",
+      "integrity": "sha512-irfJUUkEuDlNHKZNAp2r7zOyMlmbfVJ+kWSfjlCYYUx/7dJnANLCyTzQZsuxy5NJkvtNwSxY5Gj8MOlqXUQPyA=="
     },
     "shelljs": {
       "version": "0.3.0",
@@ -6904,9 +6923,9 @@
       }
     },
     "sinon-chai": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.13.0.tgz",
-      "integrity": "sha512-hRNu/TlYEp4Rw5IbzO8ykGoZMSG489PGUx1rvePpHGrtl20cXivRBgtr/EWYxIwL9EOO9+on04nd9k3tW8tVww=="
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/sinon-chai/-/sinon-chai-2.14.0.tgz",
+      "integrity": "sha512-9stIF1utB0ywNHNT7RgiXbdmen8QDCRsrTjw+G9TgKt1Yexjiv8TOWZ6WHsTPz57Yky3DIswZvEqX8fpuHNDtQ=="
     },
     "slash": {
       "version": "1.0.0",
@@ -7095,7 +7114,7 @@
       "resolved": "https://registry.npmjs.org/spdy/-/spdy-3.4.7.tgz",
       "integrity": "sha1-Qv9B7OXMD5mjpsKKq7c/XDsDrLw=",
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "handle-thing": "1.2.5",
         "http-deceiver": "1.2.7",
         "safe-buffer": "5.1.1",
@@ -7108,7 +7127,7 @@
       "resolved": "https://registry.npmjs.org/spdy-transport/-/spdy-transport-2.0.20.tgz",
       "integrity": "sha1-c15yBUxIayNU/onnAiVgBKOazk0=",
       "requires": {
-        "debug": "2.6.8",
+        "debug": "2.6.9",
         "detect-node": "2.0.3",
         "hpack.js": "2.1.6",
         "obuf": "1.1.1",
@@ -7213,11 +7232,6 @@
       "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
       "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
-    "string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
-    },
     "string-length": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-1.0.1.tgz",
@@ -7236,6 +7250,11 @@
         "is-fullwidth-code-point": "1.0.0",
         "strip-ansi": "3.0.1"
       }
+    },
+    "string_decoder": {
+      "version": "0.10.31",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "stringstream": {
       "version": "0.0.5",
@@ -7507,9 +7526,9 @@
       "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "tough-cookie": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-      "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+      "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
       "requires": {
         "punycode": "1.4.1"
       }
@@ -7616,9 +7635,9 @@
       "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "typescript": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.2.tgz",
-      "integrity": "sha1-A4qV99m7tCCxvzW6MdTFwd0//jQ=",
+      "version": "2.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.5.3.tgz",
+      "integrity": "sha512-ptLSQs2S4QuS6/OD1eAKG+S5G8QQtrU5RT32JULdZQtM1L3WTi34Wsu48Yndzi8xsObRAB9RPt/KhA9wlpEF6w==",
       "dev": true
     },
     "typical": {
@@ -7691,9 +7710,9 @@
       }
     },
     "urijs": {
-      "version": "1.18.12",
-      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.18.12.tgz",
-      "integrity": "sha512-WlvUkocbQ+GYhi8zkcbecbGYq7YLSd2I3InxAfqeh6mWvWalBE7bISDHcAL3J7STrWFfizuJ709srHD+RuABPQ=="
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/urijs/-/urijs-1.19.0.tgz",
+      "integrity": "sha512-Qs2odXn0hST5VSPVjpi73CMqtbAoanahaqWBujGU+IyMrMqpWcIhDewxQRhCkmqYxuyvICDcSuLdv2O7ncWBGw=="
     },
     "url-parse-lax": {
       "version": "1.0.0",
@@ -7730,9 +7749,9 @@
       "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.0.tgz",
-      "integrity": "sha1-ApT7kiu5N1FTVBxPcJYjHyh8ivg="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "2.0.3",
@@ -7768,9 +7787,9 @@
       "integrity": "sha1-a2GE2mUgzDIEzhtAfKwm2SYJ6/8="
     },
     "vary": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.1.tgz",
-      "integrity": "sha1-Z1Neu2lMHVIldFeYRmUyP1h+jTc="
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
@@ -8001,9 +8020,9 @@
       }
     },
     "winston": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/winston/-/winston-2.3.1.tgz",
-      "integrity": "sha1-C0hCDZeMAYBM8CMLZIhhWYIloRk=",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.0.tgz",
+      "integrity": "sha1-gIBQuT1SZh7Z+2wms/DIJnCLCu4=",
       "requires": {
         "async": "1.0.0",
         "colors": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "mocha": "^3.4.2",
     "multer": "^1.3.0",
     "nomnom": "^1.8.1",
-    "polyserve": "^0.22.1",
+    "polyserve": "^0.23.0",
     "promisify-node": "^0.4.0",
     "resolve": "^1.3.3",
     "semver": "^5.3.0",


### PR DESCRIPTION
## 6.3.0 - 2017-10-02
* Updated wct-browser-legacy to use a module version of a11ySuite to get access to Polymer.dom.flush.
* Updated generated index for webserver to use a11ySuite as a module.
* Updated polyserve to get support for on-the-fly module compilation and `<script type=module>` conversion for browsers that don't support modules.
* [x] CHANGELOG.md has been updated
