### PR TITLE
Add @polymer/polymer to wct-browser-legacy dependencies

### DIFF
--- a/wct-browser-legacy/package.json
+++ b/wct-browser-legacy/package.json
@@ -25,7 +25,7 @@
   },
   "homepage": "https://github.com/polymer/web-component-tester#readme",
   "dependencies": {
-     "@polymer/polymer": "^3.0.0-pre.1",
+    "@polymer/polymer": "^3.0.0-pre.1",
     "@polymer/sinonjs": "^1.14.1",
     "@polymer/test-fixture": "^3.0.0-pre.1",
     "@webcomponents/webcomponentsjs": "^1.0.7",

--- a/wct-browser-legacy/package.json
+++ b/wct-browser-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-browser-legacy",
-  "version": "0.0.1-pre.9",
+  "version": "0.0.1-pre.10",
   "description": "Client-side dependencies for web-component-tester tests installed via npm.",
   "main": "browser.js",
   "license": "http://polymer.github.io/LICENSE.txt",
@@ -25,6 +25,7 @@
   },
   "homepage": "https://github.com/polymer/web-component-tester#readme",
   "dependencies": {
+     "@polymer/polymer": "^3.0.0-pre.1",
     "@polymer/sinonjs": "^1.14.1",
     "@polymer/test-fixture": "^3.0.0-pre.1",
     "@webcomponents/webcomponentsjs": "^1.0.7",

--- a/wct-browser-legacy/package.json
+++ b/wct-browser-legacy/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wct-browser-legacy",
-  "version": "0.0.1-pre.8",
+  "version": "0.0.1-pre.9",
   "description": "Client-side dependencies for web-component-tester tests installed via npm.",
   "main": "browser.js",
   "license": "http://polymer.github.io/LICENSE.txt",


### PR DESCRIPTION
Since a11ySuite.js imports it, I've made `@polymer/polymer` a dependency of `wct-browser-legacy` "^3.0.0-pre.1"