### PR TITLE
Updated CHANGELOG for Halloween release of WCT 6.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased items here. -->
+
+## 6.4.0 - 2017-10-31 🎃
+
 * Updated package.json:
   * Upgraded dependencies async, chai, cleankill, findup-sync, sinon, and socket.io.
   * Upgraded devDependencies update-notifier


### PR DESCRIPTION
## 6.4.0 - 2017-10-31 🎃 
* Updated package.json:
   * Upgraded dependencies async, chai, cleankill, findup-sync, sinon, and socket.io.
   * Upgraded devDependencies update-notifier
 * Added `define:webserver` hook to enable substitution of the generated express app for the webserver through a callback, to support use cases where a plugin might want to inject handlers or middleware in front of polyserve.
 * Added support for `proxy: {path: string, target: string}` config which is forwarded to `polyserve`.
 * [x] CHANGELOG.md has been updated
