### PR TITLE
Check for Polymer being defined

### DIFF
--- a/data/a11ySuite.js
+++ b/data/a11ySuite.js
@@ -52,8 +52,10 @@
             // instantiate fixture
             fixtureElement.create();
 
-            // Make sure lazy-loaded dom is ready (eg <template is='dom-repeat'>)
-            Polymer.dom.flush();
+            if (typeof Polymer !== 'undefined') {
+              // Make sure lazy-loaded dom is ready (eg <template is='dom-repeat'>)
+              Polymer.dom.flush();
+            }
 
             // If we have a beforeEach function, call it
             if (beforeEach) {


### PR DESCRIPTION
Only call `Polymer.dom.flush()` is Polymer is found on the page, skip if not. 

Allows wct and a11ySuite to be used to test vanilla JS web components.