### PR TITLE
WCT uses webserver.hostname (#523)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 <!-- Add new, unreleased items here. -->
+Fixed #523 WCT ignores the webserver hostname
 
 ## 6.4.0 - 2017-10-31 🎃
 

--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -232,7 +232,8 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
 
     options.webserver._servers = servers.map((s) => {
       const port = s.server.address().port;
-      const url = `http://localhost:${port}${pathToGeneratedIndex}`;
+      const hostname = s.options.hostname;
+      const url = `http://${hostname}:${port}${pathToGeneratedIndex}`;
       return {url, variant: s.kind === 'mainline' ? '' : s.variantName};
     });
 


### PR DESCRIPTION
Replace hardcoded `localhost` to use the webserver hostname option.

This change allows users to utilise their own selenium grid as opposed to sauce labs.

 - [x] CHANGELOG.md has been updated
