### PR TITLE
Remove unnecessary overflow-y: auto

### DIFF
--- a/browser/reporters/html.ts
+++ b/browser/reporters/html.ts
@@ -44,7 +44,6 @@ style.textContent = `
     #mocha {
       box-sizing: border-box;
       margin: 0 !important;
-      overflow-y: auto;
       padding: 60px 20px;
       right: 0;
       left: 500px;


### PR DESCRIPTION
This seems to be slowing down testing in Polymer and provides no
discernable visual difference in the test output