### PR TITLE
Inject proper paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- Add new, unreleased items here. -->
 * Upgrade polyserve to 0.24.0 and add the --module-resolution flag
 * Fix #488 - Support .bowerrc directory name override of bower_components, including variants
+* Injected libraries are now resolved to correct paths while using the runner. Note: simply serving the test file and running it will attempt to find the files, but they may load the wrong versions (e.g. lodash 4 might load instead of 3)
 
 ## 6.5.0 - 2018-01-17
 * Upgrade wct-local to 2.1.0 to get support for headless Chrome.

--- a/test/fixtures/fake-packages/duplicated-dep/node_modules/dependency/index.js
+++ b/test/fixtures/fake-packages/duplicated-dep/node_modules/dependency/index.js
@@ -1,0 +1,1 @@
+export const a = true;

--- a/test/fixtures/fake-packages/duplicated-dep/node_modules/dependency/package.json
+++ b/test/fixtures/fake-packages/duplicated-dep/node_modules/dependency/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dependency",
+  "version": "2.0.0",
+  "main": "index.js"
+}

--- a/test/fixtures/fake-packages/duplicated-dep/node_modules/wct-browser-legacy/index.js
+++ b/test/fixtures/fake-packages/duplicated-dep/node_modules/wct-browser-legacy/index.js
@@ -1,0 +1,1 @@
+export const a = true;

--- a/test/fixtures/fake-packages/duplicated-dep/node_modules/wct-browser-legacy/node_modules/dependency/index.js
+++ b/test/fixtures/fake-packages/duplicated-dep/node_modules/wct-browser-legacy/node_modules/dependency/index.js
@@ -1,0 +1,1 @@
+export const a = true;

--- a/test/fixtures/fake-packages/duplicated-dep/node_modules/wct-browser-legacy/node_modules/dependency/pacakge.json
+++ b/test/fixtures/fake-packages/duplicated-dep/node_modules/wct-browser-legacy/node_modules/dependency/pacakge.json
@@ -1,0 +1,5 @@
+{
+  "name": "dependency",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/fixtures/fake-packages/duplicated-dep/node_modules/wct-browser-legacy/pacakge.json
+++ b/test/fixtures/fake-packages/duplicated-dep/node_modules/wct-browser-legacy/pacakge.json
@@ -1,0 +1,5 @@
+{
+  "name": "wct-browser-legacy",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/fixtures/fake-packages/duplicated-dep/package.json
+++ b/test/fixtures/fake-packages/duplicated-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "duplicated-dep",
+  "version": "1.0.0"
+}

--- a/test/fixtures/fake-packages/singleton-dep/node_modules/dependency/index.js
+++ b/test/fixtures/fake-packages/singleton-dep/node_modules/dependency/index.js
@@ -1,0 +1,1 @@
+export const a = true;

--- a/test/fixtures/fake-packages/singleton-dep/node_modules/dependency/package.json
+++ b/test/fixtures/fake-packages/singleton-dep/node_modules/dependency/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "dependency",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/fixtures/fake-packages/singleton-dep/node_modules/wct-browser-legacy/index.js
+++ b/test/fixtures/fake-packages/singleton-dep/node_modules/wct-browser-legacy/index.js
@@ -1,0 +1,1 @@
+export const a = true;

--- a/test/fixtures/fake-packages/singleton-dep/node_modules/wct-browser-legacy/package.json
+++ b/test/fixtures/fake-packages/singleton-dep/node_modules/wct-browser-legacy/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "wct-browser-legacy",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/fixtures/fake-packages/singleton-dep/package.json
+++ b/test/fixtures/fake-packages/singleton-dep/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "singleton-dep",
+  "version": "1.0.0"
+}

--- a/test/unit/config.ts
+++ b/test/unit/config.ts
@@ -12,9 +12,11 @@
  * http://polymer.github.io/PATENTS.txt
  */
 import * as chai from 'chai';
+import * as path from 'path';
 
 import * as config from '../../runner/config';
 import {Context} from '../../runner/context';
+
 const expect = chai.expect;
 
 describe('config', function() {
@@ -85,6 +87,41 @@ describe('config', function() {
       });
     });
 
+  });
+
+  describe('npm pathing', function() {
+    describe('Resolves simple names to paths', function() {
+      const localPackagePath =
+          path.join(__dirname, '../fixtures/fake-packages/singleton-dep');
+      const options = <config.Config>{root: localPackagePath};
+      const npmPackages: config.NPMPackage[] = [{
+        name: 'dependency',
+        jsEntrypoints: ['index.js', 'arbitraryJsFile.js']
+      }];
+      const resolvedEntrypoints =
+          config.resolveWCTNPMEntrypointNames(options, npmPackages);
+
+      expect(resolvedEntrypoints[0]).to.equal('dependency/index.js');
+      expect(resolvedEntrypoints[1]).to.equal('dependency/arbitraryJsFile.js');
+    });
+
+    it('Resolves duplicated names to paths', function() {
+      const localPackagePath =
+          path.join(__dirname, '../fixtures/fake-packages/duplicated-dep');
+      const options = <config.Config>{root: localPackagePath};
+      const npmPackages: config.NPMPackage[] = [{
+        name: 'dependency',
+        jsEntrypoints: ['index.js', 'arbitraryJsFile.js']
+      }];
+      const resolvedEntrypoints =
+          config.resolveWCTNPMEntrypointNames(options, npmPackages);
+
+      expect(resolvedEntrypoints[0])
+          .to.equal('wct-browser-legacy/node_modules/dependency/index.js');
+      expect(resolvedEntrypoints[1])
+          .to.equal(
+              'wct-browser-legacy/node_modules/dependency/arbitraryJsFile.js');
+    });
   });
 
 });


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md has been updated

fixes #674 

In this PR we fix the issue where `browser.js` injects libraries to the wrong paths. An example where this happens:

```
my-element
 ├ test/
 | └ index.js
 └ node_modules/
   ├ lodash(v4)/
   └ wct-browser-legacy/
     ├ browser.js
     └ node_modules/
         └ lodash(v3)/
```

in this case `browser.js` wants to inject lodash v3, but `browser.js` simply injects `../../lodash/index.js` from `my-element/test/index.js`. this means that `browser.js` is actually pointing to lodash v4 which is not browser runnable. This PR makes it so that the runner:

1. Resolves `wct-browser-legacy` if in NPM mode
2. Resolves the injected library paths from `wct-browser-legacy`
   * or whatever npm package name you pass into `--wct-package-name`
3. Passes these paths to `browser.js` via `WCT.environmentScripts` in the generated index
4. Injects these resolved paths

So with these changes, the case above is now injecting `../../wct-browser-legacy/node_modules/lodash/index.js`. If you simply serve this file and run it without the runner, `browser.js` will simply inject what it did before. This works when there are no npm version conflicts.

You may want to look at [this commit](https://github.com/Polymer/web-component-tester/commit/4e50d3133fa2ed94ecd50c74c0db2f494cec9777) if you don't want to wade through all of the test fixtures I've added.