### PR TITLE
Fixes #547 : --webserver-port option doesn't change the actual port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 * Upgrade polyserve to 0.24.0 and add the --module-resolution flag
 * Fix #488 - Support .bowerrc directory name override of bower_components, including variants
 * Fixed #547: WCT now respects webserver.port configuration option
-* Refactored #523: Defaults for hostname are correctly used
 * Injected libraries are now resolved to correct paths while using the runner. Note: simply serving the test file and running it will attempt to find the files, but they may load the wrong versions (e.g. lodash 4 might load instead of 3)
 
 ## 6.5.0 - 2018-01-17

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- Add new, unreleased items here. -->
 * Upgrade polyserve to 0.24.0 and add the --module-resolution flag
 * Fix #488 - Support .bowerrc directory name override of bower_components, including variants
+* Fixed #547: WCT now respects webserver.port configuration option
+* Refactored #523: Defaults for hostname are correctly used
 
 ## 6.5.0 - 2018-01-17
 * Upgrade wct-local to 2.1.0 to get support for headless Chrome.

--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -261,8 +261,8 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
     }
 
     options.webserver._servers = servers.map((s) => {
-      const hostname = s.server.address().address;
       const port = s.server.address().port;
+      const hostname = s.options.hostname;
       const url = `http://${hostname}:${port}${pathToGeneratedIndex}`;
       return {url, variant: s.kind === 'mainline' ? '' : s.variantName};
     });

--- a/runner/webserver.ts
+++ b/runner/webserver.ts
@@ -184,6 +184,7 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
           componentDir,
           compile: options.compile,
           hostname: options.webserver.hostname,
+          port: options.webserver.port,
           headers: DEFAULT_HEADERS,
           packageName,
           additionalRoutes,
@@ -233,8 +234,8 @@ Expected to find a ${mdFilenames.join(' or ')} at: ${pathToLocalWct}/
     }
 
     options.webserver._servers = servers.map((s) => {
+      const hostname = s.server.address().address;
       const port = s.server.address().port;
-      const hostname = s.options.hostname;
       const url = `http://${hostname}:${port}${pathToGeneratedIndex}`;
       return {url, variant: s.kind === 'mainline' ? '' : s.variantName};
     });


### PR DESCRIPTION
<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

Fixes #547. Ensure that the correct default value used when user does not set the port.

 - [ x ] CHANGELOG.md has been updated
