### PR TITLE
Handle content loading timeouts more gracefuly.

### DIFF
--- a/browser/childrunner.ts
+++ b/browser/childrunner.ts
@@ -127,6 +127,12 @@ export default class ChildRunner {
   loaded(error: any) {
     util.debug('ChildRunner#loaded', this.url, error);
 
+    if (this.iframe.contentWindow == null && error) {
+      this.signalRunComplete(error);
+      this.done();
+      return;
+    }
+
     // Not all targets have WCT loaded (compatiblity mode)
     if (this.iframe.contentWindow.WCT) {
       this.share = this.iframe.contentWindow.WCT.share;


### PR DESCRIPTION
This converts some errors that look like `Test run ended in failure: Error thrown outside of test function: Cannot read property 'WCT' of null`

into ones that look like `Timed out loading http://localhost/:17604/components/my-component/test.html`

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [x] CHANGELOG.md not updated, minor internal change
