### PR TITLE
Add env vars to specify which browsers to test in integration tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,17 +4,17 @@ addons:
   firefox: latest
   apt:
     sources:
-      - google-chrome
+    - google-chrome
     packages:
-      - google-chrome-stable
+    - google-chrome-stable
   sauce_connect: true
 language: node_js
 node_js:
-  - node
-  - '6'
+- node
+- '6'
 script:
-  - xvfb-run npm test
+- xvfb-run npm test
 env:
   global:
-    - secure: erPJ5uPudGD1E05tCYCWk/sdSFYL5lK/7rzUPgijC27XtuTF0tvvLKJkId2sCzPb40yCBHhEv0UIVEnYzY4feCpx5kUqm+Iu6DHWDn4xJP+gRnCNMCJp0QcUFU3JDNGK07FG2mKUkxD8EHxYjATL7tnN9HduNxaornVapkgRu70=
-    - secure: WkrrR4HpJr1jD86mOegdumhLqI5M1skh2j1iX0AYF41oPym4CIRHvFA8REY1f12OlPXfXCVZL8+7nyuoM6NEyddEDzZZXmgAJVFkFbP++veVjXGVAWsr2++n5lzcUfvhIuYTxTqSTpnA6E3DhoJdXBxt0FBTFxYA3yXSIfJsu2k=
+  - secure: WqREPJCj0auiij7P86MfTpD5+buf7vlAuRiUILmcq0+rhVFvsgqG82NlKIjcQuCzM9WFMqBHxDyV0/iyfE5qiQsEXYd7g3SwMVFIAS3R8sKnMz/EMA0kCqFCGn14iwbakNduSuyjQhxHje72iczm/3S4nKFceOzDGFlnvGLxpTA=
+  - secure: D5P88V2PQF6mq/bPHlpzW1DgPSz4rKaoXJ1SNIsdeqUnd8xN+tmVUBO0/skunwIPIdws0y7cLfZOThEJuRMoDMUal0Fh81UcWna+yfM5N5NYziyCsOcf60UCZLpWdvS8QNEL0zGff6apO/TEaUkgYx7IMdzi0Bu+56v/iybwM3Q=

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,5 @@ script:
 - xvfb-run npm test
 env:
   global:
-  - TEST_LOCAL_BROWSERS=chrome,firefox
-  - TEST_REMOTE_BROWSERS="Windows 10/microsoftedge@15,OS X 10.12/safari@11"
   - secure: WqREPJCj0auiij7P86MfTpD5+buf7vlAuRiUILmcq0+rhVFvsgqG82NlKIjcQuCzM9WFMqBHxDyV0/iyfE5qiQsEXYd7g3SwMVFIAS3R8sKnMz/EMA0kCqFCGn14iwbakNduSuyjQhxHje72iczm/3S4nKFceOzDGFlnvGLxpTA=
   - secure: D5P88V2PQF6mq/bPHlpzW1DgPSz4rKaoXJ1SNIsdeqUnd8xN+tmVUBO0/skunwIPIdws0y7cLfZOThEJuRMoDMUal0Fh81UcWna+yfM5N5NYziyCsOcf60UCZLpWdvS8QNEL0zGff6apO/TEaUkgYx7IMdzi0Bu+56v/iybwM3Q=

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,6 @@ script:
 - xvfb-run npm test
 env:
   global:
+  - MOCHA_TIMEOUT=300000
   - secure: WqREPJCj0auiij7P86MfTpD5+buf7vlAuRiUILmcq0+rhVFvsgqG82NlKIjcQuCzM9WFMqBHxDyV0/iyfE5qiQsEXYd7g3SwMVFIAS3R8sKnMz/EMA0kCqFCGn14iwbakNduSuyjQhxHje72iczm/3S4nKFceOzDGFlnvGLxpTA=
   - secure: D5P88V2PQF6mq/bPHlpzW1DgPSz4rKaoXJ1SNIsdeqUnd8xN+tmVUBO0/skunwIPIdws0y7cLfZOThEJuRMoDMUal0Fh81UcWna+yfM5N5NYziyCsOcf60UCZLpWdvS8QNEL0zGff6apO/TEaUkgYx7IMdzi0Bu+56v/iybwM3Q=

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,5 +16,7 @@ script:
 - xvfb-run npm test
 env:
   global:
+  - TEST_LOCAL_BROWSERS=chrome,firefox
+  - TEST_REMOTE_BROWSERS="Windows 10/microsoftedge@15,OS X 10.12/safari@11"
   - secure: WqREPJCj0auiij7P86MfTpD5+buf7vlAuRiUILmcq0+rhVFvsgqG82NlKIjcQuCzM9WFMqBHxDyV0/iyfE5qiQsEXYd7g3SwMVFIAS3R8sKnMz/EMA0kCqFCGn14iwbakNduSuyjQhxHje72iczm/3S4nKFceOzDGFlnvGLxpTA=
   - secure: D5P88V2PQF6mq/bPHlpzW1DgPSz4rKaoXJ1SNIsdeqUnd8xN+tmVUBO0/skunwIPIdws0y7cLfZOThEJuRMoDMUal0Fh81UcWna+yfM5N5NYziyCsOcf60UCZLpWdvS8QNEL0zGff6apO/TEaUkgYx7IMdzi0Bu+56v/iybwM3Q=

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -24,6 +24,10 @@ const rollup = require('rollup');
 const runSequence = require('run-sequence');
 const typescript = require('typescript');
 
+const mochaConfig = { reporter: 'spec' };
+if (process.env.MOCHA_TIMEOUT) {
+  mochaConfig.timeout = parseInt(process.env.MOCHA_TIMEOUT, 10);
+}
 
 // const commonTools = require('tools-common/gulpfile');
 const commonTools = {
@@ -154,7 +158,7 @@ gulp.task('build:wct-browser-legacy', [
 
 gulp.task('test:unit', function () {
   return gulp.src('test/unit/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec', timeout: 30000 }));
+    .pipe(mocha(mochaConfig));
 });
 
 gulp.task('bower', function () {
@@ -163,7 +167,7 @@ gulp.task('bower', function () {
 
 gulp.task('test:integration', ['bower'], function () {
   return gulp.src('test/integration/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec', timeout: 120000 }));
+    .pipe(mocha(mochaConfig));
 });
 
 gulp.task('tslint', () =>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -163,7 +163,7 @@ gulp.task('bower', function () {
 
 gulp.task('test:integration', ['bower'], function () {
   return gulp.src('test/integration/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec', timeout: 90000 }));
+    .pipe(mocha({ reporter: 'spec', timeout: 120000 }));
 });
 
 gulp.task('tslint', () =>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ gulp.task('build:wct-browser-legacy', [
 
 gulp.task('test:unit', function () {
   return gulp.src('test/unit/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec' }));
+    .pipe(mocha({ reporter: 'spec', timeout: 10000 }));
 });
 
 gulp.task('bower', function () {
@@ -163,7 +163,7 @@ gulp.task('bower', function () {
 
 gulp.task('test:integration', ['bower'], function () {
   return gulp.src('test/integration/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec' }));
+    .pipe(mocha({ reporter: 'spec', timeout: 60000 }));
 });
 
 gulp.task('tslint', () =>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -163,7 +163,7 @@ gulp.task('bower', function () {
 
 gulp.task('test:integration', ['bower'], function () {
   return gulp.src('test/integration/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec', timeout: 600000 }));
+    .pipe(mocha({ reporter: 'spec', timeout: 90000 }));
 });
 
 gulp.task('tslint', () =>

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -154,7 +154,7 @@ gulp.task('build:wct-browser-legacy', [
 
 gulp.task('test:unit', function () {
   return gulp.src('test/unit/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec', timeout: 10000 }));
+    .pipe(mocha({ reporter: 'spec', timeout: 30000 }));
 });
 
 gulp.task('bower', function () {
@@ -163,7 +163,7 @@ gulp.task('bower', function () {
 
 gulp.task('test:integration', ['bower'], function () {
   return gulp.src('test/integration/*.js', { read: false })
-    .pipe(mocha({ reporter: 'spec', timeout: 60000 }));
+    .pipe(mocha({ reporter: 'spec', timeout: 600000 }));
 });
 
 gulp.task('tslint', () =>

--- a/test/fixtures/integration/components_dir/wct.conf.json
+++ b/test/fixtures/integration/components_dir/wct.conf.json
@@ -1,0 +1,10 @@
+{
+  "plugins": {
+    "local": {
+      "browsers": [
+        "chrome"
+      ],
+      "skipSeleniumInstall": true
+    }
+  }
+}

--- a/test/fixtures/integration/custom-components_dir/test/index.html
+++ b/test/fixtures/integration/custom-components_dir/test/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../../../browser.js"></script>
+    <script src="/components/web-component-tester/browser.js"></script>
   </head>
   <body>
     <script src="../../bar-element/bar-element.js"></script>

--- a/test/fixtures/integration/custom-multiple-component_dirs/test/index.html
+++ b/test/fixtures/integration/custom-multiple-component_dirs/test/index.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <script src="../../../../browser.js"></script>
+    <script src="/components/web-component-tester/browser.js"></script>
   </head>
   <body>
     <script src="../../package/index.js"></script>

--- a/test/integration/browser.ts
+++ b/test/integration/browser.ts
@@ -11,7 +11,6 @@
  * subject to an additional IP rights grant found at
  * http://polymer.github.io/PATENTS.txt
  */
-
 import {expect} from 'chai';
 import * as express from 'express';
 import * as fs from 'fs';
@@ -31,6 +30,19 @@ function parseList(stringList?: string): string[] {
       .split(',')
       .map((item) => item.trim())
       .filter((item) => !!item);
+}
+
+function loadOptionsFile(dir: string): config.Config {
+  const filename = path.join(dir, 'wct.conf.json');
+  try {
+    const jsonOptions = fs.readFileSync(filename, 'utf-8').toString();
+    const parsedOptions = JSON.parse(jsonOptions);
+    if (parsedOptions !== null && typeof parsedOptions === 'object') {
+      return parsedOptions;
+    }
+  } catch (e) {
+    return {};
+  }
 }
 
 const testLocalBrowsers = !process.env.SKIP_LOCAL_BROWSERS;
@@ -161,6 +173,27 @@ function runsIntegrationSuite(
 
     before(async function() {
       const suiteRoot = await makeProperTestDir(dirName);
+      const suiteOptions = <any>loadOptionsFile(
+          path.join('test', 'fixtures', 'integration', dirName));
+      // Filter the list of browsers within the suite's options by the global
+      // overrides if they are present.
+      if (suiteOptions.plugins !== undefined) {
+        if (testLocalBrowsersList.length > 0 &&
+            !testLocalBrowsersList.includes('default') &&
+            suiteOptions.plugins.local !== undefined &&
+            suiteOptions.plugins.local.browsers !== undefined) {
+          suiteOptions.plugins.local.browsers =
+              suiteOptions.plugins.local.browsers.filter(
+                  (b: string) => testLocalBrowsersList.includes(b));
+        }
+        if (testRemoteBrowsersList.length > 0 &&
+            suiteOptions.plugins.sauce !== undefined &&
+            suiteOptions.plugins.sauce.browsers !== undefined) {
+          suiteOptions.plugins.sauce.browsers =
+              suiteOptions.plugins.sauce.browsers.filter(
+                  (b: string) => testRemoteBrowsersList.includes(b));
+        }
+      }
       const allOptions: config.Config = Object.assign(
           {
             output: <any>{write: log.push.bind(log)},
@@ -171,7 +204,7 @@ function runsIntegrationSuite(
               tags: ['org:Polymer', 'repo:web-component-tester'],
             },
           },
-          options);
+          options, suiteOptions);
       const context = new Context(allOptions);
 
       const addEventHandler = (name: string, handler: Function) => {
@@ -249,27 +282,22 @@ function runsIntegrationSuite(
   });
 }
 
-if (testLocalBrowsers) {
-  describe('Local Browser Tests', function() {
+if (testLocalBrowsers || testRemoteBrowsers) {
+  describe('Browser Tests', function() {
+    const pluginConfig = <any>{};
+    if (testLocalBrowsers) {
+      pluginConfig.local = {
+        browsers: testLocalBrowsersList,
+        skipSeleniumInstall: true,
+      };
+    }
+    if (testRemoteBrowsers) {
+      pluginConfig.sauce = {
+        browsers: testRemoteBrowsersList,
+      };
+    }
     runsAllIntegrationSuites({
-      plugins: <any> {
-        local: {
-          browsers: testLocalBrowsersList,
-          skipSeleniumInstall: true,
-        },
-      }
-    });
-  });
-}
-
-if (testRemoteBrowsers) {
-  describe('Remote Browser Tests', function() {
-    runsAllIntegrationSuites({
-      plugins: <any> {
-        sauce: {
-          browsers: testRemoteBrowsersList,
-        },
-      }
+      plugins: pluginConfig,
     });
   });
 }

--- a/test/integration/browser.ts
+++ b/test/integration/browser.ts
@@ -160,10 +160,6 @@ function runsIntegrationSuite(
     const testResults = new TestResults();
 
     before(async function() {
-      // TODO(usergenic): Don't use suite-specific timeouts.  Move to global
-      // mocha.opts
-      this.timeout(500 * 1000);
-
       const suiteRoot = await makeProperTestDir(dirName);
       const allOptions: config.Config = Object.assign(
           {
@@ -420,9 +416,6 @@ function repeatBrowsers<T>(
 
 describe('define:webserver hook', () => {
   it('supports substituting given app', async function() {
-    // TODO(usergenic): Don't use suite-specific timeouts.  Move to global
-    // mocha.opts
-    this.timeout(20 * 1000);
     const suiteRoot = await makeProperTestDir('define-webserver-hook');
     const log: string[] = [];
     const requestedUrls: string[] = [];
@@ -436,6 +429,7 @@ describe('define:webserver hook', () => {
       },
       plugins: <any>{
         local: {
+          browsers: testLocalBrowsersList,
           skipSeleniumInstall: true,
         }
       },
@@ -468,9 +462,6 @@ describe('define:webserver hook', () => {
 describe('early failures', () => {
   it(`wct doesn't start testing if it's not bower installed locally`,
      async function() {
-       // TODO(usergenic): Don't use suite-specific timeouts.  Move to global
-       // mocha.opts
-       this.timeout(20 * 1000);
        const log: string[] = [];
        const options: config.Config = {
          output: <any>{write: log.push.bind(log)},
@@ -482,11 +473,7 @@ describe('early failures', () => {
            tags: ['org:Polymer', 'repo:web-component-tester'],
          },
          plugins: <any>{
-           local: {
-             // Uncomment to customize the browsers to test when debugging.
-             //  browsers: ['firefox', 'chrome', 'safari'],
-             skipSeleniumInstall: true
-           },
+           local: {browsers: testLocalBrowsersList, skipSeleniumInstall: true},
          },
        };
        const context = new Context(options);
@@ -511,7 +498,7 @@ describe('early failures', () => {
            tags: ['org:Polymer', 'repo:web-component-tester'],
          },
          plugins: <any>{
-           local: {skipSeleniumInstall: true},
+           local: {browsers: testLocalBrowsersList, skipSeleniumInstall: true},
          },
        };
        const context = new Context(options);


### PR DESCRIPTION
* `TEST_LOCAL_BROWSERS=chrome,firefox`
* `TEST_REMOTE_BROWSERS=OS X 10.12/safari@11`

Integration tests already support `SKIP_LOCAL_BROWSERS` and `SKIP_REMOTE_BROWSERS`.