### PR TITLE
Fix path to config.ts in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ Alternatively, you can specify these options via the `clientOptions`
 key in `wct.conf.json`.
 
 A reference of the default configuration can be found at
-[browser/config.js](browser/config.js).
+[browser/config.ts](browser/config.ts).
 
 
 ## Gulp


### PR DESCRIPTION
As it was pointing to 404 at config.js

<!--
  Thanks for the PR!

  If this change has a user visible change (including
  bug fixes, new features, etc) please describe the change in
  CHANGELOG.md.

  If the change is an entirely package-internal reshuffling/refactoring
  should the change not be described in the CHANGELOG.

  Consider also updating the README.

  More info: http://keepachangelog.com/en/0.3.0/
 -->

 - [ ] CHANGELOG.md has been updated
